### PR TITLE
Bloodlands fixes and enhancements  (#783)

### DIFF
--- a/Segments/Bloodlands.mapproj
+++ b/Segments/Bloodlands.mapproj
@@ -345,13 +345,16 @@
         </component>
       </tile>
       <tile x="3" y="-14">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="4" y="-14">
@@ -385,13 +388,16 @@
         </component>
       </tile>
       <tile x="9" y="-14">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="10" y="-14">
@@ -425,53 +431,68 @@
         </component>
       </tile>
       <tile x="15" y="-14">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="16" y="-14">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="17" y="-14">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
+        <component type="WallComponent">
           <color r="0" g="0" b="0" a="255" />
-          <obstruction>104</obstruction>
-          <blockVision>true</blockVision>
+          <wall>104</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="18" y="-14">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
+        <component type="WallComponent">
           <color r="0" g="0" b="0" a="255" />
-          <obstruction>104</obstruction>
-          <blockVision>true</blockVision>
+          <wall>104</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="19" y="-14">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
+        <component type="WallComponent">
           <color r="0" g="0" b="0" a="255" />
-          <obstruction>104</obstruction>
-          <blockVision>true</blockVision>
+          <wall>104</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="20" y="-14">
@@ -483,33 +504,42 @@
         </component>
       </tile>
       <tile x="21" y="-14">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
+        <component type="WallComponent">
           <color r="0" g="0" b="0" a="255" />
-          <obstruction>104</obstruction>
-          <blockVision>true</blockVision>
+          <wall>104</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="22" y="-14">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
+        <component type="WallComponent">
           <color r="0" g="0" b="0" a="255" />
-          <obstruction>104</obstruction>
-          <blockVision>true</blockVision>
+          <wall>104</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="23" y="-14">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
+        <component type="WallComponent">
           <color r="0" g="0" b="0" a="255" />
-          <obstruction>104</obstruction>
-          <blockVision>true</blockVision>
+          <wall>104</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="24" y="-14">
@@ -620,23 +650,29 @@
         </component>
       </tile>
       <tile x="14" y="-13">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="15" y="-13">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="16" y="-13">
@@ -646,13 +682,16 @@
         </component>
       </tile>
       <tile x="17" y="-13">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
+        <component type="WallComponent">
           <color r="0" g="0" b="0" a="255" />
-          <obstruction>104</obstruction>
-          <blockVision>true</blockVision>
+          <wall>104</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="18" y="-13">
@@ -681,15 +720,30 @@
         <component type="FloorComponent">
           <ground>6</ground>
         </component>
+        <component type="StaticComponent">
+          <static>167</static>
+        </component>
+        <component type="HiddenTeleporterComponent">
+          <destinationX>20</destinationX>
+          <destinationY>-8</destinationY>
+          <destinationRegion>1</destinationRegion>
+          <lightphases select="all" />
+          <moonphases select="all" />
+          <professions select="all" />
+          <alignments select="all" />
+        </component>
       </tile>
       <tile x="23" y="-13">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
+        <component type="WallComponent">
           <color r="0" g="0" b="0" a="255" />
-          <obstruction>104</obstruction>
-          <blockVision>true</blockVision>
+          <wall>104</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="24" y="-13">
@@ -732,6 +786,7 @@
           <closedId>63</closedId>
           <secretId>26</secretId>
           <destroyedId>81</destroyedId>
+          <isSecret>true</isSecret>
         </component>
       </tile>
       <tile x="3" y="-12">
@@ -800,13 +855,16 @@
         </component>
       </tile>
       <tile x="14" y="-12">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="15" y="-12">
@@ -826,13 +884,16 @@
         </component>
       </tile>
       <tile x="17" y="-12">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
+        <component type="WallComponent">
           <color r="0" g="0" b="0" a="255" />
-          <obstruction>104</obstruction>
-          <blockVision>true</blockVision>
+          <wall>104</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="18" y="-12">
@@ -863,13 +924,16 @@
         </component>
       </tile>
       <tile x="23" y="-12">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
+        <component type="WallComponent">
           <color r="0" g="0" b="0" a="255" />
-          <obstruction>104</obstruction>
-          <blockVision>true</blockVision>
+          <wall>104</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="24" y="-12">
@@ -1009,13 +1073,16 @@
         </component>
       </tile>
       <tile x="15" y="-11">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="16" y="-11">
@@ -1025,13 +1092,16 @@
         </component>
       </tile>
       <tile x="17" y="-11">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
+        <component type="WallComponent">
           <color r="0" g="0" b="0" a="255" />
-          <obstruction>104</obstruction>
-          <blockVision>true</blockVision>
+          <wall>104</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="18" y="-11">
@@ -1062,13 +1132,16 @@
         </component>
       </tile>
       <tile x="23" y="-11">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
+        <component type="WallComponent">
           <color r="0" g="0" b="0" a="255" />
-          <obstruction>104</obstruction>
-          <blockVision>true</blockVision>
+          <wall>104</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="24" y="-11">
@@ -1093,13 +1166,16 @@
         </component>
       </tile>
       <tile x="0" y="-10">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="1" y="-10">
@@ -1183,23 +1259,29 @@
         </component>
       </tile>
       <tile x="13" y="-10">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="14" y="-10">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="15" y="-10">
@@ -1209,86 +1291,107 @@
         </component>
       </tile>
       <tile x="16" y="-10">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="17" y="-10">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
+        <component type="WallComponent">
           <color r="0" g="0" b="0" a="255" />
-          <obstruction>104</obstruction>
-          <blockVision>true</blockVision>
+          <wall>104</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="18" y="-10">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
+        <component type="WallComponent">
           <color r="0" g="0" b="0" a="255" />
-          <obstruction>104</obstruction>
-          <blockVision>true</blockVision>
+          <wall>104</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="19" y="-10">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
+        <component type="WallComponent">
           <color r="0" g="0" b="0" a="255" />
-          <obstruction>104</obstruction>
-          <blockVision>true</blockVision>
+          <wall>104</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="20" y="-10">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="DoorComponent">
+        <component type="WallComponent">
           <color r="0" g="0" b="0" a="255" />
-          <openId>374</openId>
-          <closedId>104</closedId>
-          <secretId>104</secretId>
-          <destroyedId>80</destroyedId>
-          <isSecret>true</isSecret>
+          <wall>104</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="21" y="-10">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
+        <component type="WallComponent">
           <color r="0" g="0" b="0" a="255" />
-          <obstruction>104</obstruction>
-          <blockVision>true</blockVision>
+          <wall>104</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="22" y="-10">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
+        <component type="WallComponent">
           <color r="0" g="0" b="0" a="255" />
-          <obstruction>104</obstruction>
-          <blockVision>true</blockVision>
+          <wall>104</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="23" y="-10">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
+        <component type="WallComponent">
           <color r="0" g="0" b="0" a="255" />
-          <obstruction>104</obstruction>
-          <blockVision>true</blockVision>
+          <wall>104</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="24" y="-10">
@@ -1341,13 +1444,16 @@
         </component>
       </tile>
       <tile x="5" y="-9">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="6" y="-9">
@@ -1375,13 +1481,16 @@
         </component>
       </tile>
       <tile x="10" y="-9">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="11" y="-9">
@@ -1409,13 +1518,16 @@
         </component>
       </tile>
       <tile x="14" y="-9">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="15" y="-9">
@@ -1425,13 +1537,16 @@
         </component>
       </tile>
       <tile x="16" y="-9">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="17" y="-9">
@@ -1451,17 +1566,44 @@
           <ground>374</ground>
           <movementCost>3</movementCost>
         </component>
+        <component type="WallComponent">
+          <color r="0" g="0" b="0" a="255" />
+          <wall>104</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
+        </component>
       </tile>
       <tile x="20" y="-9">
         <component type="WaterComponent">
           <ground>374</ground>
           <movementCost>3</movementCost>
         </component>
+        <component type="StaticComponent">
+          <color r="0" g="33" b="0" a="255" />
+          <static>167</static>
+        </component>
+        <component type="HiddenTeleporterComponent">
+          <destinationX>20</destinationX>
+          <destinationY>-12</destinationY>
+          <destinationRegion>1</destinationRegion>
+          <lightphases select="all" />
+          <moonphases select="all" />
+          <professions select="all" />
+          <alignments select="all" />
+        </component>
       </tile>
       <tile x="21" y="-9">
         <component type="WaterComponent">
           <ground>374</ground>
           <movementCost>3</movementCost>
+        </component>
+        <component type="WallComponent">
+          <color r="0" g="0" b="0" a="255" />
+          <wall>104</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="22" y="-9">
@@ -1521,13 +1663,16 @@
         </component>
       </tile>
       <tile x="4" y="-8">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="5" y="-8">
@@ -1602,23 +1747,29 @@
         </component>
       </tile>
       <tile x="16" y="-8">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="17" y="-8">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="18" y="-8">
@@ -1628,13 +1779,16 @@
         </component>
       </tile>
       <tile x="19" y="-8">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="20" y="-8">
@@ -1644,13 +1798,16 @@
         </component>
       </tile>
       <tile x="21" y="-8">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="22" y="-8">
@@ -1768,13 +1925,16 @@
         </component>
       </tile>
       <tile x="13" y="-7">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="14" y="-7">
@@ -1796,23 +1956,29 @@
         </component>
       </tile>
       <tile x="17" y="-7">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="18" y="-7">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="19" y="-7">
@@ -1822,13 +1988,16 @@
         </component>
       </tile>
       <tile x="20" y="-7">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="21" y="-7">
@@ -1877,13 +2046,16 @@
         </component>
       </tile>
       <tile x="1" y="-6">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="2" y="-6">
@@ -1899,13 +2071,16 @@
         </component>
       </tile>
       <tile x="4" y="-6">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="5" y="-6">
@@ -1937,13 +2112,16 @@
         </component>
       </tile>
       <tile x="9" y="-6">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="10" y="-6">
@@ -1995,13 +2173,16 @@
         </component>
       </tile>
       <tile x="17" y="-6">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="18" y="-6">
@@ -2029,13 +2210,16 @@
         </component>
       </tile>
       <tile x="22" y="-6">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="23" y="-6">
@@ -2084,33 +2268,42 @@
         </component>
       </tile>
       <tile x="3" y="-5">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="4" y="-5">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="5" y="-5">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="6" y="-5">
@@ -2300,43 +2493,55 @@
         </component>
       </tile>
       <tile x="0" y="-4">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="1" y="-4">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="2" y="-4">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="3" y="-4">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="4" y="-4">
@@ -2346,53 +2551,68 @@
         </component>
       </tile>
       <tile x="5" y="-4">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="6" y="-4">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="7" y="-4">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="8" y="-4">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="9" y="-4">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="10" y="-4">
@@ -2450,13 +2670,16 @@
         </component>
       </tile>
       <tile x="18" y="-4">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="19" y="-4">
@@ -2471,13 +2694,16 @@
         </component>
       </tile>
       <tile x="21" y="-4">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="22" y="-4">
@@ -2565,13 +2791,16 @@
         </component>
       </tile>
       <tile x="2" y="-3">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="3" y="-3">
@@ -2581,23 +2810,29 @@
         </component>
       </tile>
       <tile x="4" y="-3">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="5" y="-3">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="6" y="-3">
@@ -2607,13 +2842,16 @@
         </component>
       </tile>
       <tile x="7" y="-3">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="8" y="-3">
@@ -2629,13 +2867,16 @@
         </component>
       </tile>
       <tile x="10" y="-3">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="11" y="-3">
@@ -2799,23 +3040,29 @@
         </component>
       </tile>
       <tile x="0" y="-2">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="1" y="-2">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="2" y="-2">
@@ -2825,13 +3072,16 @@
         </component>
       </tile>
       <tile x="3" y="-2">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="4" y="-2">
@@ -2847,13 +3097,16 @@
         </component>
       </tile>
       <tile x="6" y="-2">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="7" y="-2">
@@ -2863,13 +3116,16 @@
         </component>
       </tile>
       <tile x="8" y="-2">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="9" y="-2">
@@ -3160,33 +3416,42 @@
         </component>
       </tile>
       <tile x="3" y="-1">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="4" y="-1">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="5" y="-1">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="6" y="-1">
@@ -3196,13 +3461,16 @@
         </component>
       </tile>
       <tile x="7" y="-1">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="8" y="-1">
@@ -3599,23 +3867,29 @@
         </component>
       </tile>
       <tile x="4" y="0">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="5" y="0">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="6" y="0">
@@ -3625,53 +3899,68 @@
         </component>
       </tile>
       <tile x="7" y="0">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="8" y="0">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="9" y="0">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="10" y="0">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="11" y="0">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="12" y="0">
@@ -3731,13 +4020,16 @@
         </component>
       </tile>
       <tile x="21" y="0">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="22" y="0">
@@ -3997,13 +4289,16 @@
         </component>
       </tile>
       <tile x="9" y="1">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="10" y="1">
@@ -4246,53 +4541,68 @@
         </component>
       </tile>
       <tile x="1" y="2">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="2" y="2">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="3" y="2">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="4" y="2">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="5" y="2">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="6" y="2">
@@ -4308,13 +4618,16 @@
         </component>
       </tile>
       <tile x="8" y="2">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="9" y="2">
@@ -4324,23 +4637,29 @@
         </component>
       </tile>
       <tile x="10" y="2">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="11" y="2">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="12" y="2">
@@ -4588,13 +4907,16 @@
         </component>
       </tile>
       <tile x="1" y="3">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="2" y="3">
@@ -4613,13 +4935,16 @@
         </component>
       </tile>
       <tile x="5" y="3">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="6" y="3">
@@ -4641,13 +4966,16 @@
         </component>
       </tile>
       <tile x="9" y="3">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="10" y="3">
@@ -4944,13 +5272,16 @@
         </component>
       </tile>
       <tile x="1" y="4">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="2" y="4">
@@ -4972,13 +5303,16 @@
         </component>
       </tile>
       <tile x="5" y="4">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="6" y="4">
@@ -5012,53 +5346,68 @@
         </component>
       </tile>
       <tile x="11" y="4">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="12" y="4">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="13" y="4">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="14" y="4">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="15" y="4">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="16" y="4">
@@ -5086,13 +5435,16 @@
         </component>
       </tile>
       <tile x="20" y="4">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="21" y="4">
@@ -5292,13 +5644,16 @@
         </component>
       </tile>
       <tile x="1" y="5">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="2" y="5">
@@ -5317,13 +5672,16 @@
         </component>
       </tile>
       <tile x="5" y="5">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="6" y="5">
@@ -5375,33 +5733,42 @@
         </component>
       </tile>
       <tile x="14" y="5">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="15" y="5">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="16" y="5">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="17" y="5">
@@ -5411,33 +5778,42 @@
         </component>
       </tile>
       <tile x="18" y="5">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="19" y="5">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="20" y="5">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="21" y="5">
@@ -5721,23 +6097,29 @@
         </component>
       </tile>
       <tile x="1" y="6">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="2" y="6">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="3" y="6">
@@ -5749,23 +6131,29 @@
         </component>
       </tile>
       <tile x="4" y="6">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="5" y="6">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="6" y="6">
@@ -5781,13 +6169,16 @@
         </component>
       </tile>
       <tile x="8" y="6">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="9" y="6">
@@ -5803,13 +6194,16 @@
         </component>
       </tile>
       <tile x="11" y="6">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="12" y="6">
@@ -5831,13 +6225,16 @@
         </component>
       </tile>
       <tile x="15" y="6">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="16" y="6">
@@ -6165,13 +6562,16 @@
         </component>
       </tile>
       <tile x="14" y="7">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="15" y="7">
@@ -6181,13 +6581,16 @@
         </component>
       </tile>
       <tile x="16" y="7">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="17" y="7">
@@ -6197,13 +6600,16 @@
         </component>
       </tile>
       <tile x="18" y="7">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="19" y="7">
@@ -6213,13 +6619,16 @@
         </component>
       </tile>
       <tile x="20" y="7">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="21" y="7">
@@ -6466,13 +6875,16 @@
         </component>
       </tile>
       <tile x="13" y="8">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="14" y="8">
@@ -6494,13 +6906,16 @@
         </component>
       </tile>
       <tile x="17" y="8">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="18" y="8">
@@ -6522,13 +6937,16 @@
         </component>
       </tile>
       <tile x="21" y="8">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="22" y="8">
@@ -6700,25 +7118,38 @@
           <ground>374</ground>
           <movementCost>3</movementCost>
         </component>
+        <component type="WallComponent">
+          <color r="0" g="0" b="0" a="255" />
+          <wall>104</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
+        </component>
       </tile>
       <tile x="1" y="9">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="2" y="9">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="3" y="9">
@@ -6730,23 +7161,29 @@
         </component>
       </tile>
       <tile x="4" y="9">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="5" y="9">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
+        <component type="WallComponent">
           <color r="0" g="0" b="0" a="255" />
-          <obstruction>104</obstruction>
-          <blockVision>true</blockVision>
+          <wall>104</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="6" y="9">
@@ -6774,13 +7211,16 @@
         </component>
       </tile>
       <tile x="10" y="9">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="11" y="9">
@@ -6848,13 +7288,16 @@
         </component>
       </tile>
       <tile x="21" y="9">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="22" y="9">
@@ -6999,13 +7442,16 @@
         </component>
       </tile>
       <tile x="0" y="10">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="1" y="10">
@@ -7053,13 +7499,16 @@
         </component>
       </tile>
       <tile x="5" y="10">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="6" y="10">
@@ -7069,13 +7518,16 @@
         </component>
       </tile>
       <tile x="7" y="10">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="8" y="10">
@@ -7115,13 +7567,16 @@
         </component>
       </tile>
       <tile x="14" y="10">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="15" y="10">
@@ -7161,13 +7616,16 @@
         </component>
       </tile>
       <tile x="21" y="10">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="22" y="10">
@@ -7417,13 +7875,16 @@
         </component>
       </tile>
       <tile x="5" y="11">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="6" y="11">
@@ -7439,13 +7900,16 @@
         </component>
       </tile>
       <tile x="8" y="11">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="9" y="11">
@@ -7461,13 +7925,16 @@
         </component>
       </tile>
       <tile x="11" y="11">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="12" y="11">
@@ -7477,13 +7944,16 @@
         </component>
       </tile>
       <tile x="13" y="11">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
+        <component type="WallComponent">
           <color r="0" g="0" b="0" a="255" />
-          <obstruction>104</obstruction>
-          <blockVision>true</blockVision>
+          <wall>104</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="14" y="11">
@@ -7533,13 +8003,16 @@
         </component>
       </tile>
       <tile x="21" y="11">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="22" y="11">
@@ -7809,10 +8282,12 @@
           <ground>374</ground>
           <movementCost>3</movementCost>
         </component>
-        <component type="TreeComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <tree>370</tree>
-          <canGrow>true</canGrow>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="16" y="12">
@@ -8113,13 +8588,16 @@
         </component>
       </tile>
       <tile x="13" y="13">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
+        <component type="WallComponent">
           <color r="0" g="0" b="0" a="255" />
-          <obstruction>104</obstruction>
-          <blockVision>true</blockVision>
+          <wall>104</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="14" y="13">
@@ -8135,13 +8613,16 @@
         </component>
       </tile>
       <tile x="16" y="13">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="17" y="13">
@@ -8169,13 +8650,16 @@
         </component>
       </tile>
       <tile x="21" y="13">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="22" y="13">
@@ -8362,33 +8846,42 @@
         </component>
       </tile>
       <tile x="0" y="14">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
+        <component type="WallComponent">
           <color r="0" g="0" b="0" a="255" />
-          <obstruction>104</obstruction>
-          <blockVision>true</blockVision>
+          <wall>104</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="1" y="14">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="2" y="14">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="3" y="14">
@@ -8410,13 +8903,16 @@
         </component>
       </tile>
       <tile x="5" y="14">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
+        <component type="WallComponent">
           <color r="0" g="0" b="0" a="255" />
-          <obstruction>104</obstruction>
-          <blockVision>true</blockVision>
+          <wall>104</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="6" y="14">
@@ -8514,13 +9010,16 @@
         </component>
       </tile>
       <tile x="21" y="14">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="22" y="14">
@@ -8732,13 +9231,16 @@
         </component>
       </tile>
       <tile x="13" y="15">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="14" y="15">
@@ -8784,13 +9286,16 @@
         </component>
       </tile>
       <tile x="21" y="15">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="22" y="15">
@@ -9023,13 +9528,16 @@
         </component>
       </tile>
       <tile x="10" y="16">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="11" y="16">
@@ -9051,13 +9559,16 @@
         </component>
       </tile>
       <tile x="14" y="16">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="15" y="16">
@@ -9097,13 +9608,16 @@
         </component>
       </tile>
       <tile x="21" y="16">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="22" y="16">
@@ -9249,13 +9763,16 @@
         </component>
       </tile>
       <tile x="2" y="17">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="3" y="17">
@@ -9356,13 +9873,16 @@
         </component>
       </tile>
       <tile x="18" y="17">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="19" y="17">
@@ -9614,33 +10134,42 @@
         </component>
       </tile>
       <tile x="0" y="18">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="1" y="18">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="2" y="18">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="3" y="18">
@@ -9669,13 +10198,16 @@
         </component>
       </tile>
       <tile x="6" y="18">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="7" y="18">
@@ -9731,13 +10263,16 @@
         </component>
       </tile>
       <tile x="15" y="18">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="16" y="18">
@@ -9759,33 +10294,42 @@
         </component>
       </tile>
       <tile x="19" y="18">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="20" y="18">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="21" y="18">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="22" y="18">
@@ -9998,13 +10542,16 @@
         </component>
       </tile>
       <tile x="2" y="19">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="3" y="19">
@@ -10024,13 +10571,16 @@
         </component>
       </tile>
       <tile x="5" y="19">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="6" y="19">
@@ -10040,13 +10590,16 @@
         </component>
       </tile>
       <tile x="7" y="19">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="8" y="19">
@@ -10056,23 +10609,29 @@
         </component>
       </tile>
       <tile x="9" y="19">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="10" y="19">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="11" y="19">
@@ -10128,13 +10687,16 @@
         </component>
       </tile>
       <tile x="19" y="19">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="20" y="19">
@@ -10344,13 +10906,16 @@
         </component>
       </tile>
       <tile x="1" y="20">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="2" y="20">
@@ -10360,23 +10925,29 @@
         </component>
       </tile>
       <tile x="3" y="20">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="4" y="20">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="5" y="20">
@@ -10392,13 +10963,16 @@
         </component>
       </tile>
       <tile x="7" y="20">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="8" y="20">
@@ -10432,13 +11006,16 @@
         </component>
       </tile>
       <tile x="13" y="20">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="14" y="20">
@@ -10478,13 +11055,16 @@
         </component>
       </tile>
       <tile x="20" y="20">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="21" y="20">
@@ -10710,13 +11290,16 @@
         </component>
       </tile>
       <tile x="2" y="21">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="3" y="21">
@@ -10732,13 +11315,16 @@
         </component>
       </tile>
       <tile x="5" y="21">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="6" y="21">
@@ -10754,13 +11340,16 @@
         </component>
       </tile>
       <tile x="8" y="21">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="9" y="21">
@@ -10770,13 +11359,16 @@
         </component>
       </tile>
       <tile x="10" y="21">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
+        <component type="WallComponent">
           <color r="0" g="0" b="0" a="255" />
-          <obstruction>104</obstruction>
-          <blockVision>true</blockVision>
+          <wall>104</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="11" y="21">
@@ -10794,13 +11386,16 @@
         </component>
       </tile>
       <tile x="12" y="21">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
+        <component type="WallComponent">
           <color r="0" g="0" b="0" a="255" />
-          <obstruction>104</obstruction>
-          <blockVision>true</blockVision>
+          <wall>104</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="13" y="21">
@@ -10840,23 +11435,29 @@
         </component>
       </tile>
       <tile x="19" y="21">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="20" y="21">
-        <component type="FloorComponent">
+        <component type="WaterComponent">
           <ground>374</ground>
+          <movementCost>3</movementCost>
         </component>
-        <component type="ObstructionComponent">
-          <color r="159" g="136" b="110" a="255" />
-          <obstruction>370</obstruction>
-          <blockVision>true</blockVision>
+        <component type="WallComponent">
+          <color r="159" g="133" b="112" a="255" />
+          <wall>370</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="21" y="21">
@@ -11591,10 +12192,12 @@
         <component type="FloorComponent">
           <ground>6</ground>
         </component>
-        <component type="ObstructionComponent">
+        <component type="WallComponent">
           <color r="0" g="0" b="0" a="255" />
-          <obstruction>104</obstruction>
-          <blockVision>true</blockVision>
+          <wall>104</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="11" y="23">
@@ -11615,10 +12218,12 @@
         <component type="FloorComponent">
           <ground>6</ground>
         </component>
-        <component type="ObstructionComponent">
+        <component type="WallComponent">
           <color r="0" g="0" b="0" a="255" />
-          <obstruction>104</obstruction>
-          <blockVision>true</blockVision>
+          <wall>104</wall>
+          <destroyed>41</destroyed>
+          <ruins>45</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="13" y="23">
@@ -28641,11 +29246,6 @@
       <id>5</id>
       <name>Bloodlands -300</name>
       <height>-300</height>
-      <tile x="-9" y="-3">
-        <component type="StaticComponent">
-          <static>412</static>
-        </component>
-      </tile>
       <tile x="-1" y="-1">
         <component type="WallComponent">
           <wall>355</wall>
@@ -31146,10 +31746,6 @@
         </component>
       </tile>
       <tile x="10" y="11">
-        <component type="WaterComponent">
-          <ground>602</ground>
-          <movementCost>3</movementCost>
-        </component>
         <component type="FloorComponent">
           <ground>23</ground>
         </component>
@@ -31348,19 +31944,11 @@
         </component>
       </tile>
       <tile x="10" y="12">
-        <component type="WaterComponent">
-          <ground>602</ground>
-          <movementCost>3</movementCost>
-        </component>
         <component type="FloorComponent">
           <ground>23</ground>
         </component>
       </tile>
       <tile x="11" y="12">
-        <component type="WaterComponent">
-          <ground>602</ground>
-          <movementCost>3</movementCost>
-        </component>
         <component type="FloorComponent">
           <ground>23</ground>
         </component>
@@ -31488,10 +32076,6 @@
         </component>
       </tile>
       <tile x="0" y="13">
-        <component type="WaterComponent">
-          <ground>602</ground>
-          <movementCost>3</movementCost>
-        </component>
         <component type="FloorComponent">
           <ground>23</ground>
         </component>
@@ -31563,19 +32147,11 @@
         </component>
       </tile>
       <tile x="11" y="13">
-        <component type="WaterComponent">
-          <ground>602</ground>
-          <movementCost>3</movementCost>
-        </component>
         <component type="FloorComponent">
           <ground>23</ground>
         </component>
       </tile>
       <tile x="12" y="13">
-        <component type="WaterComponent">
-          <ground>602</ground>
-          <movementCost>3</movementCost>
-        </component>
         <component type="FloorComponent">
           <ground>23</ground>
         </component>
@@ -31670,19 +32246,11 @@
         </component>
       </tile>
       <tile x="0" y="14">
-        <component type="WaterComponent">
-          <ground>602</ground>
-          <movementCost>3</movementCost>
-        </component>
         <component type="FloorComponent">
           <ground>23</ground>
         </component>
       </tile>
       <tile x="1" y="14">
-        <component type="WaterComponent">
-          <ground>602</ground>
-          <movementCost>3</movementCost>
-        </component>
         <component type="FloorComponent">
           <ground>23</ground>
         </component>
@@ -31750,19 +32318,11 @@
         </component>
       </tile>
       <tile x="11" y="14">
-        <component type="WaterComponent">
-          <ground>602</ground>
-          <movementCost>3</movementCost>
-        </component>
         <component type="FloorComponent">
           <ground>23</ground>
         </component>
       </tile>
       <tile x="12" y="14">
-        <component type="WaterComponent">
-          <ground>602</ground>
-          <movementCost>3</movementCost>
-        </component>
         <component type="FloorComponent">
           <ground>23</ground>
         </component>
@@ -31863,10 +32423,6 @@
         </component>
       </tile>
       <tile x="0" y="15">
-        <component type="WaterComponent">
-          <ground>602</ground>
-          <movementCost>3</movementCost>
-        </component>
         <component type="FloorComponent">
           <ground>23</ground>
         </component>
@@ -36157,7 +36713,7 @@
           <static>301</static>
         </component>
         <component type="HiddenTeleporterComponent">
-          <destinationX>-2</destinationX>
+          <destinationY>-14</destinationY>
           <destinationRegion>1</destinationRegion>
           <lightphases select="all" />
           <moonphases select="all" />
@@ -36527,18 +37083,11 @@
         </component>
       </tile>
       <tile x="18" y="11">
-        <component type="WaterComponent">
-          <ground>602</ground>
-          <movementCost>3</movementCost>
-        </component>
-        <component type="FloorComponent">
-          <ground>23</ground>
-        </component>
         <component type="StaircaseComponent">
           <destinationX>19</destinationX>
           <destinationY>11</destinationY>
           <destinationRegion>5</destinationRegion>
-          <teleporterId>181</teleporterId>
+          <teleporterId>8</teleporterId>
           <descends>true</descends>
         </component>
       </tile>
@@ -37411,6 +37960,7 @@
           <wall>157</wall>
           <destroyed>160</destroyed>
           <ruins>170</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="2" y="-16">
@@ -37421,6 +37971,7 @@
           <wall>157</wall>
           <destroyed>160</destroyed>
           <ruins>170</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="3" y="-16">
@@ -37444,6 +37995,7 @@
           <wall>158</wall>
           <destroyed>161</destroyed>
           <ruins>170</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="6" y="-16">
@@ -37508,6 +38060,7 @@
           <wall>158</wall>
           <destroyed>161</destroyed>
           <ruins>170</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="3" y="-15">
@@ -37518,6 +38071,7 @@
           <wall>157</wall>
           <destroyed>160</destroyed>
           <ruins>170</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="4" y="-15">
@@ -37528,6 +38082,7 @@
           <wall>157</wall>
           <destroyed>160</destroyed>
           <ruins>170</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="5" y="-15">
@@ -37538,11 +38093,13 @@
           <wall>157</wall>
           <destroyed>160</destroyed>
           <ruins>170</ruins>
+          <indestructible>true</indestructible>
         </component>
         <component type="WallComponent">
           <wall>158</wall>
           <destroyed>161</destroyed>
           <ruins>170</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="6" y="-15">
@@ -44314,13 +44871,19 @@
         <component type="StaticComponent">
           <static>167</static>
         </component>
+        <component type="HiddenTeleporterComponent">
+          <destinationX>16</destinationX>
+          <destinationY>-65</destinationY>
+          <destinationRegion>9</destinationRegion>
+          <lightphases select="all" />
+          <moonphases select="all" />
+          <professions select="all" />
+          <alignments select="all" />
+        </component>
       </tile>
       <tile x="14" y="-70">
         <component type="FloorComponent">
           <ground>12</ground>
-        </component>
-        <component type="StaticComponent">
-          <static>167</static>
         </component>
       </tile>
       <tile x="15" y="-70">
@@ -45757,8 +46320,17 @@
         </component>
       </tile>
       <tile x="16" y="-66">
-        <component type="FloorComponent">
-          <ground>12</ground>
+        <component type="StaticComponent">
+          <static>1</static>
+        </component>
+        <component type="StaticComponent">
+          <static>13</static>
+        </component>
+        <component type="WallComponent">
+          <wall>31</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="17" y="-66">
@@ -46084,21 +46656,45 @@
         </component>
       </tile>
       <tile x="9" y="-65">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <static>1</static>
         </component>
-        <component type="FloorComponent">
-          <ground>13</ground>
+        <component type="StaticComponent">
+          <static>13</static>
+        </component>
+        <component type="WallComponent">
+          <wall>31</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="10" y="-65">
-        <component type="FloorComponent">
-          <ground>12</ground>
+        <component type="StaticComponent">
+          <static>1</static>
+        </component>
+        <component type="StaticComponent">
+          <static>13</static>
+        </component>
+        <component type="WallComponent">
+          <wall>31</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="11" y="-65">
-        <component type="FloorComponent">
-          <ground>12</ground>
+        <component type="StaticComponent">
+          <static>1</static>
+        </component>
+        <component type="StaticComponent">
+          <static>13</static>
+        </component>
+        <component type="WallComponent">
+          <wall>31</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="12" y="-65">
@@ -46130,6 +46726,18 @@
       <tile x="16" y="-65">
         <component type="FloorComponent">
           <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>167</static>
+        </component>
+        <component type="HiddenTeleporterComponent">
+          <destinationX>10</destinationX>
+          <destinationY>-67</destinationY>
+          <destinationRegion>9</destinationRegion>
+          <lightphases select="all" />
+          <moonphases select="all" />
+          <professions select="all" />
+          <alignments select="all" />
         </component>
       </tile>
       <tile x="17" y="-65">
@@ -46448,8 +47056,17 @@
         </component>
       </tile>
       <tile x="11" y="-64">
-        <component type="FloorComponent">
-          <ground>13</ground>
+        <component type="StaticComponent">
+          <static>1</static>
+        </component>
+        <component type="StaticComponent">
+          <static>13</static>
+        </component>
+        <component type="WallComponent">
+          <wall>31</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="12" y="-64">
@@ -49226,12 +49843,29 @@
       </tile>
       <tile x="-20" y="-55">
         <component type="FloorComponent">
-          <ground>13</ground>
+          <ground>23</ground>
+        </component>
+        <component type="WallComponent">
+          <wall>158</wall>
+          <destroyed>161</destroyed>
+          <ruins>170</ruins>
         </component>
       </tile>
       <tile x="-19" y="-55">
         <component type="FloorComponent">
-          <ground>13</ground>
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>167</static>
+        </component>
+        <component type="HiddenTeleporterComponent">
+          <destinationX>-21</destinationX>
+          <destinationY>-55</destinationY>
+          <destinationRegion>9</destinationRegion>
+          <lightphases select="all" />
+          <moonphases select="all" />
+          <professions select="all" />
+          <alignments select="all" />
         </component>
       </tile>
       <tile x="-18" y="-55">
@@ -49831,7 +50465,19 @@
       </tile>
       <tile x="-26" y="-53">
         <component type="FloorComponent">
-          <ground>23</ground>
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>167</static>
+        </component>
+        <component type="HiddenTeleporterComponent">
+          <destinationX>-23</destinationX>
+          <destinationY>-48</destinationY>
+          <destinationRegion>9</destinationRegion>
+          <lightphases select="all" />
+          <moonphases select="all" />
+          <professions select="all" />
+          <alignments select="all" />
         </component>
       </tile>
       <tile x="-25" y="-53">
@@ -51821,8 +52467,14 @@
         </component>
       </tile>
       <tile x="-30" y="-47">
-        <component type="FloorComponent">
-          <ground>1</ground>
+        <component type="StaticComponent">
+          <static>1</static>
+        </component>
+        <component type="WallComponent">
+          <wall>31</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="-29" y="-47">
@@ -52190,7 +52842,19 @@
       </tile>
       <tile x="-30" y="-46">
         <component type="FloorComponent">
-          <ground>1</ground>
+          <ground>12</ground>
+        </component>
+        <component type="StaticComponent">
+          <static>167</static>
+        </component>
+        <component type="HiddenTeleporterComponent">
+          <destinationX>-29</destinationX>
+          <destinationY>-49</destinationY>
+          <destinationRegion>9</destinationRegion>
+          <lightphases select="all" />
+          <moonphases select="all" />
+          <professions select="all" />
+          <alignments select="all" />
         </component>
       </tile>
       <tile x="-29" y="-46">
@@ -62162,8 +62826,14 @@
         </component>
       </tile>
       <tile x="7" y="-9">
-        <component type="SkyComponent">
-          <teleporterId>9</teleporterId>
+        <component type="StaticComponent">
+          <static>1</static>
+        </component>
+        <component type="WallComponent">
+          <wall>31</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="8" y="-9">
@@ -62452,8 +63122,14 @@
         </component>
       </tile>
       <tile x="-1" y="-8">
-        <component type="SkyComponent">
-          <teleporterId>9</teleporterId>
+        <component type="StaticComponent">
+          <static>1</static>
+        </component>
+        <component type="WallComponent">
+          <wall>31</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="0" y="-8">
@@ -62481,28 +63157,58 @@
         </component>
       </tile>
       <tile x="3" y="-8">
-        <component type="SkyComponent">
-          <teleporterId>9</teleporterId>
+        <component type="StaticComponent">
+          <static>1</static>
+        </component>
+        <component type="WallComponent">
+          <wall>31</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="4" y="-8">
-        <component type="SkyComponent">
-          <teleporterId>9</teleporterId>
+        <component type="StaticComponent">
+          <static>1</static>
+        </component>
+        <component type="WallComponent">
+          <wall>31</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="5" y="-8">
-        <component type="SkyComponent">
-          <teleporterId>9</teleporterId>
+        <component type="StaticComponent">
+          <static>1</static>
+        </component>
+        <component type="WallComponent">
+          <wall>31</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="6" y="-8">
-        <component type="SkyComponent">
-          <teleporterId>9</teleporterId>
+        <component type="StaticComponent">
+          <static>1</static>
+        </component>
+        <component type="WallComponent">
+          <wall>31</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="7" y="-8">
-        <component type="SkyComponent">
-          <teleporterId>9</teleporterId>
+        <component type="StaticComponent">
+          <static>1</static>
+        </component>
+        <component type="WallComponent">
+          <wall>31</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="8" y="-8">
@@ -62791,28 +63497,58 @@
         </component>
       </tile>
       <tile x="-1" y="-7">
-        <component type="SkyComponent">
-          <teleporterId>9</teleporterId>
+        <component type="StaticComponent">
+          <static>1</static>
+        </component>
+        <component type="WallComponent">
+          <wall>31</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="0" y="-7">
-        <component type="SkyComponent">
-          <teleporterId>9</teleporterId>
+        <component type="StaticComponent">
+          <static>1</static>
+        </component>
+        <component type="WallComponent">
+          <wall>31</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="1" y="-7">
-        <component type="SkyComponent">
-          <teleporterId>9</teleporterId>
+        <component type="StaticComponent">
+          <static>1</static>
+        </component>
+        <component type="WallComponent">
+          <wall>31</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="2" y="-7">
-        <component type="SkyComponent">
-          <teleporterId>9</teleporterId>
+        <component type="StaticComponent">
+          <static>1</static>
+        </component>
+        <component type="WallComponent">
+          <wall>31</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="3" y="-7">
-        <component type="SkyComponent">
-          <teleporterId>9</teleporterId>
+        <component type="StaticComponent">
+          <static>1</static>
+        </component>
+        <component type="WallComponent">
+          <wall>31</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="4" y="-7">
@@ -75335,6 +76071,17 @@
         <component type="FloorComponent">
           <ground>12</ground>
         </component>
+        <component type="StaticComponent">
+          <static>167</static>
+        </component>
+        <component type="HiddenTeleporterComponent">
+          <destinationX>36</destinationX>
+          <destinationRegion>10</destinationRegion>
+          <lightphases select="all" />
+          <moonphases select="all" />
+          <professions select="all" />
+          <alignments select="all" />
+        </component>
       </tile>
       <tile x="43" y="-5">
         <component type="FloorComponent">
@@ -75610,11 +76357,14 @@
         </component>
       </tile>
       <tile x="36" y="-4">
-        <component type="FloorComponent">
-          <ground>12</ground>
+        <component type="StaticComponent">
+          <static>12</static>
         </component>
-        <component type="RuinsComponent">
-          <ruins>44</ruins>
+        <component type="WallComponent">
+          <wall>31</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="37" y="-4">
@@ -75977,11 +76727,14 @@
         </component>
       </tile>
       <tile x="37" y="-3">
-        <component type="FloorComponent">
-          <ground>12</ground>
+        <component type="StaticComponent">
+          <static>12</static>
         </component>
-        <component type="RuinsComponent">
-          <ruins>44</ruins>
+        <component type="WallComponent">
+          <wall>31</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="38" y="-3">
@@ -76278,11 +77031,14 @@
         </component>
       </tile>
       <tile x="37" y="-2">
-        <component type="FloorComponent">
-          <ground>12</ground>
+        <component type="StaticComponent">
+          <static>12</static>
         </component>
-        <component type="RuinsComponent">
-          <ruins>44</ruins>
+        <component type="WallComponent">
+          <wall>31</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="38" y="-2">
@@ -76572,11 +77328,14 @@
         </component>
       </tile>
       <tile x="38" y="-1">
-        <component type="FloorComponent">
-          <ground>12</ground>
+        <component type="StaticComponent">
+          <static>12</static>
         </component>
-        <component type="RuinsComponent">
-          <ruins>44</ruins>
+        <component type="WallComponent">
+          <wall>31</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="39" y="-1">
@@ -76860,6 +77619,18 @@
         <component type="FloorComponent">
           <ground>12</ground>
         </component>
+        <component type="StaticComponent">
+          <static>167</static>
+        </component>
+        <component type="HiddenTeleporterComponent">
+          <destinationX>42</destinationX>
+          <destinationY>-5</destinationY>
+          <destinationRegion>10</destinationRegion>
+          <lightphases select="all" />
+          <moonphases select="all" />
+          <professions select="all" />
+          <alignments select="all" />
+        </component>
       </tile>
       <tile x="37" y="0">
         <component type="FloorComponent">
@@ -76867,11 +77638,14 @@
         </component>
       </tile>
       <tile x="38" y="0">
-        <component type="FloorComponent">
-          <ground>12</ground>
+        <component type="StaticComponent">
+          <static>12</static>
         </component>
-        <component type="RuinsComponent">
-          <ruins>44</ruins>
+        <component type="WallComponent">
+          <wall>31</wall>
+          <destroyed>0</destroyed>
+          <ruins>0</ruins>
+          <indestructible>true</indestructible>
         </component>
       </tile>
       <tile x="39" y="0">
@@ -86043,6 +86817,7 @@
           <closedId>229</closedId>
           <secretId>25</secretId>
           <destroyedId>80</destroyedId>
+          <isSecret>true</isSecret>
         </component>
       </tile>
       <tile x="37" y="19">
@@ -86272,6 +87047,7 @@
           <closedId>67</closedId>
           <secretId>152</secretId>
           <destroyedId>85</destroyedId>
+          <isSecret>true</isSecret>
         </component>
       </tile>
       <tile x="33" y="21">
@@ -86962,9 +87738,9 @@
     };
     
     foreach (var skill in Skill.Weapons)
-        kardoz.SetTraining(skill, 12, 20);
+        kardoz.SetTraining(skill, 3, 20);
     
-    kardoz.SetTraining(Skill.Magic, 12, 20);
+    kardoz.SetTraining(Skill.Magic, 3, 20);
     
     return kardoz;
 ]]></block>
@@ -87003,7 +87779,7 @@
     foreach (var skill in Skill.Weapons)
         sven.SetTraining(skill, 4, 12);
     
-    sven.SetTraining(Skill.Magic, 12, 20);
+    sven.SetTraining(Skill.Magic, 3, 20);
     
     return sven;
 ]]></block>
@@ -87039,7 +87815,7 @@
     trainer.AddCounter(new Point2D(34, 17, 1));
     trainer.AddCounter(new Point2D(35, 17, 1));
     trainer.AddCounter(new Point2D(36, 17, 1));
-    trainer.SetTraining(Skill.Magic, 12, 20);
+    trainer.SetTraining(Skill.Magic, 3, 20);
     
     return trainer;
 ]]></block>
@@ -87250,9 +88026,9 @@
     
     lurker.AddGold(2200);
     lurker.AddLoot(new LootPack(
-        new LootPackEntry(true, MagicBottles, 5),
+        new LootPackEntry(true, MagicBottles, 3),
         new LootPackEntry(true, GenericBottles,    33),
-        new LootPackEntry(true, SemiRare, 1)
+        new LootPackEntry(true, SemiRare, 0.8)
     ));
     
     return lurker;
@@ -87283,12 +88059,12 @@
         BaseDodge = 22,
         HideDetection = 30,
         Alignment = Alignment.Evil,
-        Mana = 25, MaxMana = 25,
+        Mana = 27, MaxMana = 27,
         Experience = 94000,
-       
+        CanLoot = false,
         CanJumpkick = true,
         CanCharge = true,
-        CanSwim = false,
+        CanSwim = true,
         Body = 26,
         
         
@@ -87304,6 +88080,7 @@
     };
     
     boss1.AddStatus(new NightVisionStatus(boss1));
+    boss1.AddStatus(new BreatheWaterStatus(boss1));
     
     boss1.CombatantChangeInterval = TimeSpan.FromSeconds(6.0);
     
@@ -87375,7 +88152,7 @@
         BaseDodge = 16,
         Immunity = CreatureImmunity.Magic,
         Weakness = CreatureWeakness.BlueGlowing | CreatureWeakness.IceSpearSpell | CreatureWeakness.DeathSpell,
-        Experience = 8600,
+        Experience = 14600,
         BasePenetration = ShieldPenetration.Medium,
         Attacks = new CreatureAttackCollection()
         {
@@ -87526,7 +88303,7 @@
         case 2: source.Say($"Welcome to town {player.Name}"); break;
         case 3: source.Say($"Keep an eye out, I've seen griffins wander into town"); break;
         case 4: source.Say($"Hey {player.Name} I've heard romor of a ghastly beast up north"); break;
-        case 5: source.Emote($"mumbles about always being on shift and never getting  break"); break;
+        case 5: source.Emote($"mumbles about always being on shift and never getting a break"); break;
    }
 ]]></block>
         <block><![CDATA[]]></block>
@@ -87635,25 +88412,25 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="100Hobs">
+    <entity name="hobs100">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
 	//todo make these hobgoblins speedy. Right now they're a copy of -300.
     var hobgoblin = new Hobgoblin()
     {
-        MaxHealth = 165, Health = 160,
+        MaxHealth = 265, Health = 260,
         MaxMana = 13, Mana = 13,
         BaseDodge = 15,
 
-        Experience = 8500,
+        Experience = 9500,
         BasePenetration = ShieldPenetration.Medium,
     };
     hobgoblin.AddStatus(new NightVisionStatus(hobgoblin));
     
     hobgoblin.Attacks = new CreatureAttackCollection
     {
-        new CreatureBasicAttack(14, 21, 26)
+        new CreatureBasicAttack(16, 32, 41)
     };
     hobgoblin.Spells = new CreatureSpellCollection()
     {
@@ -87691,14 +88468,14 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="100Archer">
+    <entity name="archer100">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
 	var orc = new Orc()
     {
-        MaxHealth = 110, Health = 110,
-        BaseDodge = 12,
+        MaxHealth = 125, Health = 125,
+        BaseDodge = 15,
         BasePenetration = ShieldPenetration.Light,
         Experience = 5800,
         
@@ -87707,19 +88484,21 @@
     
     orc.Attacks = new CreatureAttackCollection()
     {
-        new CreatureBasicAttack(10)
+        new CreatureBasicAttack(17)
     };
-    
+    orc.AddStatus(new NightVisionStatus(orc));
     orc.Wield(new Longbow());
     orc.Equip(new LeatherArmor());
             
-    orc.AddGold(250);
+    orc.AddGold(450);
     orc.AddLoot(new LootPack(
         new LootPackEntry(true, drop3gems,       10,     gemsPriceMutator), 
+        new LootPackEntry(true, (from, container) => new PermanentConstitutionPotion(), 5.0), 
         new LootPackEntry(true, GenericBottles,    33)
+        
     ));
     
-    //need to add lootpack
+
      
     return orc;
 ]]></block>
@@ -87738,14 +88517,14 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="100Kobald">
+    <entity name="kobald100">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
 	 var kobold = new Kobold()
     {
-        MaxHealth = 145, Health = 145,
-        BaseDodge = 13,
+        MaxHealth = 175, Health = 175,
+        BaseDodge = 18,
         
         Experience = 8002,
         
@@ -87759,7 +88538,7 @@
     
     kobold.Attacks = new CreatureAttackCollection
     {
-        new CreatureBasicAttack(14, 18, 23)
+        new CreatureBasicAttack(17, 23, 40)
     };
     
     kobold.Wield(new SteelMace());
@@ -87799,7 +88578,7 @@
         MaxHealth = 150, Health = 150,
         BaseDodge = 12,
     
-        Experience = 2725,
+        Experience = 14725,
         
     };
     wraith.AddStatus(new NightVisionStatus(wraith));
@@ -87895,8 +88674,8 @@
         <block><![CDATA[
 	var skeleton = new Skeleton()
     {
-        MaxHealth = 150, Health = 150,
-        BaseDodge = 14,
+        MaxHealth = 175, Health = 175,
+        BaseDodge = 16,
 
         Experience = 6800,
         BasePenetration = ShieldPenetration.Light,
@@ -87906,7 +88685,7 @@
     
     skeleton.Attacks = new CreatureAttackCollection()
     {
-        new CreatureBasicAttack(13, 20, 30)
+        new CreatureBasicAttack(15, 28, 38)
     };
     
     skeleton.Wield(new Spear());
@@ -87940,7 +88719,7 @@
     {
         Name = "mummy",
         MaxHealth = 350, Health = 350,
-        BaseDodge = 15,
+        BaseDodge = 18,
         HideDetection = 26,
         Experience = 19000,
     
@@ -88063,10 +88842,10 @@
         <block><![CDATA[
 	var banshee = new Banshee()
     {
-        MaxHealth = 165, Health = 150,
+        MaxHealth = 165, Health = 165,
         BaseDodge = 18,
     
-        Experience = 6800,
+        Experience = 9800,
         BasePenetration = ShieldPenetration.Light,
         MaxMana = 21, Mana = 21,
         DeathResistance = 100,
@@ -88115,7 +88894,7 @@
 	 var orc = new Orc()
     {
         MaxHealth = 130, Health = 130,
-        BaseDodge = 14,
+        BaseDodge = 17,
                 
         Experience = 5200,
         BasePenetration = ShieldPenetration.Light,
@@ -88124,7 +88903,7 @@
     
     orc.Attacks = new CreatureAttackCollection()
     {
-        new CreatureBasicAttack(14, 25, 35)
+        new CreatureBasicAttack(15, 29, 39)
     };
     
     orc.Wield(new Longsword());
@@ -88132,7 +88911,11 @@
             
     orc.AddGold(400);
     
-    //todo add lootpack
+    orc.AddLoot(new LootPack(
+        new LootPackEntry(true, MagicBottles, 2),
+        new LootPackEntry(true, GenericBottles,    33),
+        new LootPackEntry(true, SemiRare, 0.5)
+    ));
     
     return orc;
 ]]></block>
@@ -88151,17 +88934,17 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="KeepOfDarknessBoss">
+    <entity name="keepOfDarknessBoss">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
 	var mummy = new Mummy()
     {
         Name = "Jormin",
-        MaxHealth = 2350, Health = 2350,
-        BaseDodge = 15,
+        MaxHealth = 8350, Health = 8350,
+        BaseDodge = 25,
         HideDetection = 26,
-        Experience = 34000,
+        Experience = 44000,
         CanSwim = true,
     
         BasePenetration = ShieldPenetration.Heavy,
@@ -88171,14 +88954,15 @@
     };
     
     mummy.AddStatus(new NightVisionStatus(mummy));
+    mummy.AddStatus(new BreatheWaterStatus(mummy));
     
     mummy.Attacks = new CreatureAttackCollection()
     {
         { 
-            new CreatureAttack(16,     35, 55,     "The mummy strangles you with his bandages"),      70, TimeSpan.Zero 
+            new CreatureAttack(19,     35, 55,     "The mummy strangles you with his bandages"),      70, TimeSpan.Zero 
         }, 
         { 
-            new CreatureAttack(17,    45, 65,     "A mummified claw scratches you.",
+            new CreatureAttack(20,    45, 65,     "A mummified claw scratches you.",
                                                     new AttackAgeComponent(100, 50)),             30, TimeSpan.Zero
         },
         //todo who added TimeSpan to these?
@@ -88191,7 +88975,17 @@
     };
     
     mummy.AddGold(4000);
-    
+     mummy.AddLoot(new LootPack(
+        new LootPackEntry(true, (from, container) => new PearDiamond(3000u),    100, gemsPriceMutator),
+        new LootPackEntry(true, (from, container) => new PearDiamond(3000u),    50, gemsPriceMutator),
+        new LootPackEntry(true, (from, container) => new PearDiamond(3000u),    50, gemsPriceMutator),
+        new LootPackEntry(true, (from, container) => new BearSkull(),        100),
+        new LootPackEntry(true, (from, container) => new YouthPotion(),        100),
+         new LootPackEntry(true, SemiRare, 40),
+        new LootPackEntry(true, (from, container) => new SilverDaggerAmulet(),        40),        
+        new LootPackEntry(true, UltraRare, 25)
+
+    ));
     //todo add lootpack
     
     return mummy;
@@ -88212,7 +89006,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="200boss">
+    <entity name="boss200">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -88220,8 +89014,8 @@
     {
         Name = "Urgnah The Orc", Body=30, IsFemale = false,
        
-        MaxHealth = 1830, Health = 1830,
-        BaseDodge = 17,
+        MaxHealth = 3830, Health = 3830,
+        BaseDodge = 21,
                 
         Experience = 19000,
         BasePenetration = ShieldPenetration.Light,
@@ -88232,7 +89026,7 @@
     orc.AddStatus(new NightVisionStatus(orc));
     orc.Attacks = new CreatureAttackCollection()
     {
-        new CreatureBasicAttack(13, 25, 35)
+        new CreatureBasicAttack(17, 25, 35)
     };
     
     orc.Wield(new Longsword());
@@ -88246,7 +89040,7 @@
         new LootPackEntry(true, UltraRare, 1)
     ));
     
-    //todo add lootpack
+
     
     return orc;
 ]]></block>
@@ -88315,10 +89109,10 @@
 	var giant = new Giant()
     {
         Name = "Voracious Giant",
-        MaxHealth = 1450, Health = 1450,
+        MaxHealth = 2950, Health = 2950,
         BaseDodge = 24,
     
-        Experience = 21000,
+        Experience = 40000,
         
         HideDetection = 22,
         
@@ -88334,21 +89128,22 @@
     };
     
     giant.AddStatus(new NightVisionStatus(giant));
-    
+    giant.AddStatus(new BreatheWaterStatus(giant));
+    giant.Equip(new DrakeScaleArmor());
     giant.Attacks = new CreatureAttackCollection
     {
         {
-            new CreatureAttack(13,      53, 78,      "The giant smashes you with his fist.",
+            new CreatureAttack(18,      53, 78,      "The giant smashes you with his fist.",
                                                         new AttackProneComponent(15), 
                                                         new AttackStunComponent(5)),                40
         },
         {
-            new CreatureAttack(13,      63, 88,     "The giant stomps on you.",
+            new CreatureAttack(19,      63, 85,     "The giant stomps on you.",
                                                         new AttackProneComponent(25), 
                                                         new AttackStunComponent(10)),               40
         },
         {
-            new CreatureAttack(11,      73, 100,     "The giant slams you across the room.",
+            new CreatureAttack(20,      73, 95,     "The giant slams you across the room.",
                                                         new AttackProneComponent(100), 
                                                         new AttackStunComponent(15)),               20
         },
@@ -88455,7 +89250,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="300Lurker">
+    <entity name="lurker300">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -88469,15 +89264,15 @@
         CanSwim = true,
         CanWalk = false,
         
-        Experience = 8000,
+        Experience = 18000,
             
         VisibilityDistance = 0,
     };
     
     lurker.Attacks = new CreatureAttackCollection()
     {
-        { new CreatureAttack(11,     15, 20,      "The lurker whips you with a tentacle"),  50 }, 
-        { new CreatureAttack(12,     1, 30,     "The lurker bites you.",
+        { new CreatureAttack(19,     35, 55,      "The lurker whips you with a tentacle"),  50 }, 
+        { new CreatureAttack(20,     45, 70,     "The lurker bites you.",
                                                     new AttackPoisonComponent(15)),          50 },
     };
     
@@ -88511,7 +89306,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="300SurfaceWyvern">
+    <entity name="surfaceWyvern300">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -88520,7 +89315,7 @@
         Name = "Slime Wyvern",
         Body = 65,
         MaxHealth = 190, Health = 190,
-        BaseDodge = 14,
+        BaseDodge = 22,
                 
         Experience = 6500,
     
@@ -88530,17 +89325,17 @@
         //todo add poison prot
         
     };
-    
+    wyvern.AddStatus(new BreatheWaterStatus(wyvern));
     wyvern.Attacks = new CreatureAttackCollection()
     {
         {
-            new CreatureAttack(14,     15, 22,   "The wyvern rakes you with its claws."),        50 
+            new CreatureAttack(18,     22, 32,   "The wyvern rakes you with its claws."),        50 
         },
         {
-            new CreatureAttack(15,     23, 29,   "The wyvern bites you."),                     30 
+            new CreatureAttack(19,     33, 39,   "The wyvern bites you."),                     30 
         },
         {
-            new CreatureAttack(16,     29, 35,  "The wyvern rakes whips you with its tail."),  20 
+            new CreatureAttack(23,     35, 40,  "The wyvern rakes whips you with its tail."),  20 
         }
     };
     
@@ -88575,15 +89370,15 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="300Boss">
+    <entity name="boss300water">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
 	var wyrm = new Wyrm()
     {
         Name = "Apep",
-        MaxHealth = 2500, Health = 2500,
-        BaseDodge = 18,
+        MaxHealth = 4500, Health = 4500,
+        BaseDodge = 22,
 
         Experience = 42000,
         HideDetection = 25,
@@ -88599,14 +89394,15 @@
                    CreatureImmunity.Bashing | CreatureImmunity.Poison | CreatureImmunity.Magic,
         Weakness = CreatureWeakness.Silver | CreatureWeakness.IceSpearSpell | CreatureWeakness.DeathSpell,
     };
-    
+    wyrm.AddStatus(new NightVisionStatus(wyrm));
+    wyrm.AddStatus(new BreatheWaterStatus(wyrm));
     wyrm.Attacks = new CreatureAttackCollection
     {
         {
-            new CreatureAttack(15, 45, 60, "You've been bitten by the wyrm."),  40 
+            new CreatureAttack(18, 45, 60, "You've been bitten by the wyrm."),  40 
         }, 
         {
-            new CreatureAttack(16, 50, 65, "The wyrm hits you with its tail."), 40 
+            new CreatureAttack(19, 50, 65, "The wyrm hits you with its tail."), 40 
         }, 
         {
             new CreatureAttack(25,      60, 80,     "The wyrm crushes you with its body",
@@ -88650,7 +89446,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="300TrollGuards">
+    <entity name="trollGuards300">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -88673,7 +89469,7 @@
     
     trollguard.Attacks = new CreatureAttackCollection()
     {
-        new CreatureBasicAttack(17, 45, 55)
+        new CreatureBasicAttack(19, 48, 59)
     };
     
     trollguard.Wield(new Halberd());
@@ -88699,7 +89495,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="300HutKeeper">
+    <entity name="hutKeeper300">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -88708,7 +89504,7 @@
         Name = "Lardil the disgraced", Alignment = Alignment.Evil,
         Body = 48,
     
-        MaxHealth = 1500, Health = 1500,
+        MaxHealth = 3500, Health = 3500,
         BaseDodge = 22,
           
         Experience = 15000,
@@ -88736,7 +89532,7 @@
     
     ydnac.Attacks = new CreatureAttackCollection
     {
-        new CreatureBasicAttack(18)
+        new CreatureBasicAttack(55)
     };
     
     ydnac.Spells = new CreatureSpellCollection()
@@ -88779,7 +89575,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="300TrollGuardRanged">
+    <entity name="trollGuardRanged300">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -88802,7 +89598,7 @@
     
     trollguard.Attacks = new CreatureAttackCollection()
     {
-        new CreatureBasicAttack(17, 35, 45)
+        new CreatureBasicAttack(18, 35, 45)
     };
     
     trollguard.Wield(new ReturningHammer());
@@ -88882,7 +89678,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="300CastleSpectre">
+    <entity name="castlespec300">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -88890,7 +89686,7 @@
     {
         MaxHealth = 250, Health = 250,
         MaxMana = 44, Mana = 44,
-        BaseDodge = 16,
+        BaseDodge = 20,
     
         Experience = 9500,
         BasePenetration = ShieldPenetration.Light,
@@ -88902,7 +89698,7 @@
     
     spectre.Attacks = new CreatureAttackCollection()
     {
-        new CreatureBasicAttack(12, 20, 30)
+        new CreatureBasicAttack(18, 40, 50)
     };
     
     spectre.Spells = new CreatureSpellCollection()
@@ -88937,7 +89733,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="300EvilStatue">
+    <entity name="evilStatue300">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -88946,7 +89742,7 @@
         Name = "Evil Statue",
         Body = 99,
         
-        MaxHealth = 50, Health = 50,
+        MaxHealth = 100, Health = 100,
         BaseDodge = 15,
         
         Movement = 0,
@@ -88958,7 +89754,7 @@
     
     statue.Attacks = new CreatureAttackCollection
     {
-        new CreatureBasicAttack(6)
+        new CreatureBasicAttack(10)
     };
     
     statue.Spells = new CreatureSpellCollection(100.0)
@@ -88983,7 +89779,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="300Dweller">
+    <entity name="dweller300">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -88995,7 +89791,7 @@
         Body = 14, IsFemale = female,
             
         MaxHealth = 355, Health = 355,
-        BaseDodge = 19,
+        BaseDodge = 20,
         BasePenetration = ShieldPenetration.Light,
         Experience = 17000,
         CanSwim = true,
@@ -89004,7 +89800,7 @@
         
     fighter.Attacks = new CreatureAttackCollection
     {
-        new CreatureBasicAttack(17, 25, 55)
+        new CreatureBasicAttack(21, 35, 65)
     };
     
     fighter.Wield(new Longsword());
@@ -89031,7 +89827,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="300King">
+    <entity name="king300">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -89046,9 +89842,11 @@
         BaseDodge = 15,
         HideDetection = 27,
         BasePenetration = ShieldPenetration.Light,
-        Experience = 8500,
+        Experience = 80500,
         CanSwim = false,
         Alignment = Alignment.Chaotic,
+        Immunity = CreatureImmunity.Magic,
+        Weakness = CreatureWeakness.BlueGlowing | CreatureWeakness.IceSpearSpell | CreatureWeakness.DeathSpell,
             
     };
         
@@ -89106,7 +89904,7 @@
         <block><![CDATA[]]></block>
       </script>
     </entity>
-    <entity name="300Queen">
+    <entity name="queen300">
       <script name="OnSpawn" enabled="true">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -89120,9 +89918,11 @@
         BaseDodge = 15,
         HideDetection = 27,
         BasePenetration = ShieldPenetration.Light,
-        Experience = 8500,
+        Experience = 80500,
         CanSwim = false,
         Alignment = Alignment.Chaotic,
+        Immunity = CreatureImmunity.Magic,
+        Weakness = CreatureWeakness.BlueGlowing | CreatureWeakness.IceSpearSpell | CreatureWeakness.DeathSpell,
             
     };
         
@@ -89190,7 +89990,7 @@
         MaxHealth = 225, Health = 225,
         BaseDodge = 26,
         
-        Experience = 12000,        
+        Experience = 22000,        
         
         BasePenetration = ShieldPenetration.Medium,
         
@@ -89206,10 +90006,10 @@
     boar.Attacks = new CreatureAttackCollection
     {
         { 
-            new CreatureAttack(15, 23, 37, "A spectral tusk impales you."), 60 
+            new CreatureAttack(17, 23, 37, "A  tusk impales you."), 60 
         }, 
         {
-            new CreatureAttack(17, 28, 45, "The boar charges through you."), 40 
+            new CreatureAttack(19, 28, 45, "The boar charges through you."), 40 
         }, 
     };
     
@@ -89253,7 +90053,7 @@
         MaxHealth = 1200, Health = 1200,
         BaseDodge = 25,
                 
-        Experience = 25000,
+        Experience = 33000,
         
         
         
@@ -89270,13 +90070,13 @@
     bear.Attacks = new CreatureAttackCollection
     {
         {
-            new CreatureAttack(15,     45, 55,  "The bear  slashes you with razor claws."),        50 
+            new CreatureAttack(17,     45, 55,  "The bear  slashes you with razor claws."),        50 
         },
         {
-            new CreatureAttack(17,     50, 67,  "The bear strike passes through your defenses."),   40 
+            new CreatureAttack(18,     50, 67,  "The bear strike passes through your defenses."),   40 
         },
         {
-            new CreatureAttack(18,     60, 81, "The bear batters you with impossible force."),            10 
+            new CreatureAttack(20,     60, 81, "The bear batters you with impossible force."),            10 
         }
     };
         
@@ -89319,7 +90119,7 @@
         MaxHealth = 225, Health = 225,
         BaseDodge = 29,
         BasePenetration = ShieldPenetration.Heavy,
-        Experience = 12000,
+        Experience = 14000,
 
         MagicProtection = 50,
     };
@@ -89329,13 +90129,13 @@
     wolf.Attacks = new CreatureAttackCollection
     {
             { 
-                new CreatureAttack(14, 18, 30, "The wolf rakes you with its claws."),         50 
+                new CreatureAttack(17, 18, 30, "The wolf rakes you with its claws."),         50 
             }, 
             {
-                new CreatureAttack(15, 25, 37, "The wolf sinks its teeth into you."),         30
+                new CreatureAttack(18, 25, 37, "The wolf sinks its teeth into you."),         30
             }, 
             { 
-                new CreatureAttack(16, 38, 45, "The wolf lunges at you, biting into your neck."), 20 
+                new CreatureAttack(20, 38, 45, "The wolf lunges at you, biting into your neck."), 20 
             }, 
     };
     
@@ -89349,7 +90149,7 @@
       wolf.AddLoot(new LootPack(
         new LootPackEntry(true, drop3gems,       10,     gemsPriceMutator), 
         new LootPackEntry(true, GenericBottles,    33),
-        new LootPackEntry(true, SemiRare, 3)
+        new LootPackEntry(true, SemiRare, 1)
     ));
 
     return wolf;
@@ -89381,20 +90181,30 @@
         BaseDodge = 28,
         MagicProtection = 50,
         CanCharge = true,
-        Experience = 12000,
+        Experience = 13000,
         VisibilityDistance = 1,
         
     };
     
-    viper.Attacks = new CreatureAttackCollection()
+
+    viper.Attacks = new CreatureAttackCollection
     {
-        new CreatureAttack(18,     10, 30,      "The viper sinks its fangs into your flesh.", 
-                                            new AttackPoisonComponent(29))
-    };  
+        {
+            new CreatureAttack(18, 13, 30, "The viper tears your flesh with its fangs."),   40 
+        }, 
+        {
+            new CreatureAttack(19, 20, 30, "The viper buries its poisonous fangs into you.",
+                                                    new AttackPoisonComponent(40)),         30
+        }, 
+        {
+            new CreatureAttack(19, 30, 45, "The viper kicks you."),      30
+        }, 
+    };
+    
     
     viper.Blocks = new CreatureBlockCollection
     {
-        new CreatureBlock(1, "your weapon blocked by the vipers tail."),
+        new CreatureBlock(5, "your weapon blocked by the vipers fangs."),
     };
 
    viper.AddGold(1000);
@@ -89439,7 +90249,7 @@
     
     centaur.Attacks = new CreatureAttackCollection
     {
-        new CreatureBasicAttack(16, 25, 35)
+        new CreatureBasicAttack(19, 25, 45)
     };
     
     centaur.Spells = new CreatureSpellCollection()
@@ -89498,14 +90308,14 @@
     griffin.Attacks = new CreatureAttackCollection
     {
         {
-            new CreatureAttack(14, 18, 26, "The griffin tears your flesh with its beak."),   40 
+            new CreatureAttack(17, 18, 26, "The griffin tears your flesh with its beak."),   40 
         }, 
         {
-            new CreatureAttack(15, 20, 35, "The griffin buries its talons into you.",
+            new CreatureAttack(18, 20, 35, "The griffin buries its talons into you.",
                                                     new AttackStunComponent(20.0)),         30
         }, 
         {
-            new CreatureAttack(16, 30, 45, "The griffin pummels you with its wings."),      30
+            new CreatureAttack(19, 30, 45, "The griffin pummels you with its wings."),      30
         }, 
     };
         
@@ -89555,14 +90365,15 @@
     var unicorn = new Drake()
     {
         Name = "Corrupt Unicorn",
-        MaxHealth = 7900, Health = 7900,
-        BaseDodge = 25,
+        MaxHealth = 9900, Health = 9900,
+        BaseDodge = 26,
         Body = 45,
-        MaxMana = 25,
+        MaxMana = 45,
     
         Alignment = Alignment.Evil,
         HideDetection = 30,
         Experience = 72000,
+        CanLoot = false,
         
         
         CanCharge = true,
@@ -89577,22 +90388,22 @@
     
     unicorn.AddStatus(new NightVisionStatus(unicorn));
     
-    unicorn.CombatantChangeInterval = TimeSpan.FromSeconds(10.0);
+    unicorn.CombatantChangeInterval = TimeSpan.FromSeconds(6.0);
     
     unicorn.Attacks = new CreatureAttackCollection()
     {
         {
-            new CreatureAttack(17,      55, 70,      "The Unicorn stomps you with its hooves.",
+            new CreatureAttack(19,      55, 70,      "The Unicorn stomps you with its hooves.",
                                                         new AttackProneComponent(15), 
                                                         new AttackStunComponent(5)),                40
         },
         {
-            new CreatureAttack(18,      60, 75,     "The Unicorn smashes you with its hind legs.",
+            new CreatureAttack(21,      60, 75,     "The Unicorn smashes you with its hind legs.",
                                                         new AttackProneComponent(25), 
                                                         new AttackStunComponent(10)),               40
         },
         {
-            new CreatureAttack(21,      70, 89,     "The Unicorn pierces you with its horn.",
+            new CreatureAttack(25,      70, 89,     "The Unicorn pierces you with its horn.",
                                                         new AttackProneComponent(35), 
                                                         new AttackStunComponent(15)),               20
         },
@@ -89600,9 +90411,9 @@
     
     unicorn.Blocks = new CreatureBlockCollection
     {
-        new CreatureBlock(6, "hard horn"),
-        new CreatureBlock(4, "a hoof"),
-        new CreatureBlock(3, "a tail"),
+        new CreatureBlock(9, "hard horn"),
+        new CreatureBlock(7, "a hoof"),
+        new CreatureBlock(6, "a tail"),
     };
         
     unicorn.Spells = new CreatureSpellCollection(20.0)
@@ -89729,7 +90540,7 @@
         Body = 162,
         Immunity = CreatureImmunity.Magic,
         Weakness = CreatureWeakness.BlueGlowing | CreatureWeakness.IceSpearSpell | CreatureWeakness.DeathSpell,
-        Experience = 8200,
+        Experience = 14200,
             
         VisibilityDistance = 0,
     };
@@ -89786,7 +90597,7 @@
         Alignment = Alignment.Evil,
         
 
-        Experience = 17350,
+        Experience = 32350,
         
         MagicProtection = 100,
         Immunity = CreatureImmunity.Magic,
@@ -89799,27 +90610,27 @@
     griffin.Attacks = new CreatureAttackCollection
     {
         {
-            new CreatureAttack(14, 18, 26, "The griffin tears your flesh with its beak."),   40 
+            new CreatureAttack(19, 18, 28, "The griffin tears your flesh with its beak."),   40 
         }, 
         {
-            new CreatureAttack(15, 20, 35, "The griffin buries its talons into you.",
+            new CreatureAttack(20, 20, 38, "The griffin buries its talons into you.",
                                                     new AttackStunComponent(20.0)),         30
         }, 
         {
-            new CreatureAttack(16, 30, 45, "The griffin pummels you with its wings."),      30
+            new CreatureAttack(22, 30, 45, "The griffin pummels you with its wings."),      30
         }, 
     };
         
     griffin.Blocks = new CreatureBlockCollection
     {
         {
-            new CreatureBlock(6, "the armor")
+            new CreatureBlock(7, "the armor")
         }, 
         {
-            new CreatureBlock(4, "a talon")
+            new CreatureBlock(8, "a talon")
         }, 
         {
-            new CreatureBlock(3, "a beak") 
+            new CreatureBlock(4, "a beak") 
         }, 
     };
 
@@ -89859,7 +90670,7 @@ var ghoul = new Ghoul()
         MaxHealth = 290, Health = 290,
         BaseDodge = 19,
     
-        Experience = 7500,
+        Experience = 12500,
     
         Movement = 2,
         BasePenetration = ShieldPenetration.Light,
@@ -89869,7 +90680,7 @@ var ghoul = new Ghoul()
     ghoul.Attacks = new CreatureAttackCollection
     {
         { 
-            new CreatureAttack(15,     35, 42,      "The ghoul scratches you with its claws"),  70 
+            new CreatureAttack(16,     35, 42,      "The ghoul scratches you with its claws"),  70 
         }, 
         { 
             new CreatureAttack(19,     42, 55,     "You've been bitten by the ghoul",
@@ -89966,23 +90777,27 @@ var ghoul = new Ghoul()
         Body = 246, IsFemale = female,
             
         MaxHealth = 455, Health = 455,
-        BaseDodge = 21,
+        BaseDodge = 26,
         BasePenetration = ShieldPenetration.Light,
         Experience = 27000,
-        CanSwim = true,
-            
+        CanSwim = true,        
     };
-        
+    abomination.AddStatus(new NightVisionStatus(abomination));
+    abomination.AddStatus(new BreatheWaterStatus(abomination));
     abomination.Attacks = new CreatureAttackCollection
     {
-        new CreatureBasicAttack(19, 35, 55)
+        new CreatureBasicAttack(20, 35, 55)
     };
     
     abomination.Wield(new Longsword());
     abomination.Equip(new PlatemailArmor());    
     
-    abomination.AddGold(450);
-    
+    abomination.AddGold(1450);
+    abomination.AddLoot(new LootPack(
+        new LootPackEntry(true, drop3gems,       10,     gemsPriceMutator), 
+        new LootPackEntry(true, GenericBottles,    33),
+        new LootPackEntry(true, SemiRare, 3)
+    ));
     //todo add lootpack
     
     return abomination;
@@ -90008,25 +90823,26 @@ var ghoul = new Ghoul()
         <block><![CDATA[
 	var banshee = new Banshee()
     {
-        MaxHealth = 265, Health = 250,
+        MaxHealth = 265, Health = 265,
         BaseDodge = 18,
     
-        Experience = 6800,
+        Experience = 14800,
         BasePenetration = ShieldPenetration.Light,
         MaxMana = 21, Mana = 21,
         DeathResistance = 100,
         MagicProtection = 33,
-    };
         
+    };
+        banshee.AddStatus(new NightVisionStatus(banshee));    
     banshee.Attacks = new CreatureAttackCollection()
     {
-        new CreatureBasicAttack(45)
+           new CreatureBasicAttack(20, 30, 39)
     };
     
     banshee.Spells = new CreatureSpellCollection()
     {
         new CreatureSpell<CurseSpell>(
-            skillLevel:11, cost: 10, 
+            skillLevel:10, cost: 10, 
             mantra: SpellHelper.GenerateMantra(), instantCast: false)
     };
         
@@ -90034,7 +90850,11 @@ var ghoul = new Ghoul()
         
     banshee.AddGold(480);
     
-    //todo add lootpack
+ banshee.AddLoot(new LootPack(
+        new LootPackEntry(true, drop3gems,       10,     gemsPriceMutator), 
+        new LootPackEntry(true, GenericBottles,    33),
+        new LootPackEntry(true, SemiRare, 3)
+    ));
     
     return banshee;
 ]]></block>
@@ -90061,7 +90881,7 @@ var ghoul = new Ghoul()
     {
         MaxHealth = 370, Health = 370,
         BaseDodge = 23,
-        Name = "Bat",
+        Name = "Cave Bat",
         CanFly = true,
         Alignment = Alignment.Chaotic,
         Body = 222,
@@ -90079,14 +90899,14 @@ var ghoul = new Ghoul()
     bat.Attacks = new CreatureAttackCollection
     {
         {
-            new CreatureAttack(15, 20, 30, "The bat tears your flesh with its claws."),   40 
+            new CreatureAttack(18, 20, 30, "The bat tears your flesh with its claws."),   40 
         }, 
         {
-            new CreatureAttack(16, 30, 40, "The bat buries sinks its fangs into you.",
+            new CreatureAttack(19, 30, 40, "The bat buries sinks its fangs into you.",
                                                     new AttackStunComponent(20.0)),         30
         }, 
         {
-            new CreatureAttack(19, 40, 55, "The bat pummels you with its wings."),      30
+            new CreatureAttack(21, 40, 55, "The bat pummels you with its wings."),      30
         }, 
     };
         
@@ -90113,6 +90933,804 @@ var ghoul = new Ghoul()
    
 
     return bat;
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnDeath" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnIncomingPlayer" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+    </entity>
+    <entity name="shark300">
+      <script name="OnSpawn" enabled="true">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+	var shark = new Shark()
+    {
+        MaxHealth = 525, Health = 525,
+        BaseDodge = 23,
+
+        Experience = 12225,
+    };    
+    
+    shark.Attacks = new CreatureAttackCollection
+    {
+        {
+            new CreatureAttack(20, 45, 55, "You've been bitten by the shark."),       60 
+        }, 
+        {
+            new CreatureAttack(22, 40, 65, "The shark lashes you with its fin."),    40
+        }, 
+    };
+    
+    shark.Blocks = new CreatureBlockCollection
+    {
+        new CreatureBlock(9, "the tough skin"),
+        new CreatureBlock(10, "a fin")
+    };
+
+    shark.AddGold(450);
+    shark.AddLoot(
+        new LootPack(
+            new LootPackEntry(true, (from, container) => new OysterPearl(3000u), 7.69),
+            new LootPackEntry(true, SemiRare, 5)
+            
+
+        ));
+
+    return shark;
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnDeath" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnIncomingPlayer" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+    </entity>
+    <entity name="pirhana300">
+      <script name="OnSpawn" enabled="true">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+	var piranha = new Piranha()
+    {
+        MaxHealth = 199, Health = 199,
+        BaseDodge = 22,
+    
+        Experience = 3221,
+    
+        Movement = 1,
+        
+        VisibilityDistance = 0,
+        RangePerception = 0,
+        
+        BasePenetration = ShieldPenetration.Medium,
+    
+        FireProtection = 100,
+        IceProtection = 100,
+        // TODO: WHIRLWIND PROTECTION 100
+        // TODO: POISON PROTECTION 100
+        CanWalk = false,
+        CanSwim = true,
+    };    
+    piranha.AddStatus(new BreatheWaterStatus(piranha));
+    
+    piranha.Attacks = new CreatureAttackCollection
+    {
+        { new CreatureAttack(18,     25, 35,   "The piranha swarm upon you"),      70 }, 
+        { new CreatureAttack(21,     35, 55,  "The piranha bite you"),            30 }, 
+    };
+        
+    piranha.Blocks = new CreatureBlockCollection
+    {
+        new CreatureBlock(8, "the armor"), 
+        new CreatureBlock(6, "a tail"), 
+    };
+    
+    piranha.AddGold(300);
+        
+    return piranha;
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnDeath" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnIncomingPlayer" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+    </entity>
+    <entity name="archer200">
+      <script name="OnSpawn" enabled="true">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+	var orc = new Orc()
+    {
+        MaxHealth = 225, Health = 225,
+        BaseDodge = 18,
+        BasePenetration = ShieldPenetration.Light,
+        Experience = 9800,
+        
+        CanFlee = true,
+    };
+    
+    orc.Attacks = new CreatureAttackCollection()
+    {
+        new CreatureBasicAttack(21)
+    };
+    orc.AddStatus(new NightVisionStatus(orc));
+    orc.Wield(new Longbow());
+    orc.Equip(new LeatherArmor());
+            
+    orc.AddGold(750);
+    orc.AddLoot(new LootPack(
+        new LootPackEntry(true, drop3gems,       10,     gemsPriceMutator),
+        new LootPackEntry(true, (from, container) => new PermanentConstitutionPotion(), 5.0), 
+        new LootPackEntry(true, GenericBottles,    33)
+    ));
+    
+
+     
+    return orc;
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnDeath" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnIncomingPlayer" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+    </entity>
+    <entity name="hobs200">
+      <script name="OnSpawn" enabled="true">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+	//todo make these hobgoblins speedy. Right now they're a copy of -300.
+    var hobgoblin = new Hobgoblin()
+    {
+        MaxHealth = 365, Health = 360,
+        MaxMana = 13, Mana = 25,
+        BaseDodge = 19,
+
+        Experience = 13500,
+        BasePenetration = ShieldPenetration.Medium,
+    };
+    hobgoblin.AddStatus(new NightVisionStatus(hobgoblin));
+    
+    hobgoblin.Attacks = new CreatureAttackCollection
+    {
+        new CreatureBasicAttack(19, 39, 51)
+    };
+    hobgoblin.Spells = new CreatureSpellCollection()
+    {
+        new CreatureSpell<LightningBoltSpell>(
+            skillLevel: 7, cost: 13, 
+            mantra: SpellHelper.GenerateMantra(), instantCast: false),
+    };
+    
+    hobgoblin.Wield(new Longsword());
+    hobgoblin.Equip(new LeatherArmor());    
+    
+    hobgoblin.AddGold(700);
+    hobgoblin.AddLoot(new LootPack(
+        new LootPackEntry(true, drop3gems,       10,     gemsPriceMutator), 
+        new LootPackEntry(true, GenericBottles,    33)
+    ));
+    
+    //Need to add in new loot
+    
+    
+    return hobgoblin;
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnDeath" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnIncomingPlayer" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+    </entity>
+    <entity name="kobold200">
+      <script name="OnSpawn" enabled="true">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+	 var kobold = new Kobold()
+    {
+        MaxHealth = 275, Health = 275,
+        BaseDodge = 21,
+        
+        Experience = 12002,
+        
+        Movement = 3,
+        
+        Attacks = new CreatureAttackCollection()
+        {
+            new CreatureBasicAttack(3)
+        },
+    };
+    
+    kobold.Attacks = new CreatureAttackCollection
+    {
+        new CreatureBasicAttack(19, 33, 50)
+    };
+    
+    kobold.Wield(new SteelMace());
+    kobold.Equip(new LeatherArmor());
+    
+    kobold.AddGold(472);
+    kobold.AddLoot(new LootPack(
+        new LootPackEntry(true, drop3gems,       10,     gemsPriceMutator), 
+        new LootPackEntry(true, GenericBottles,    33)
+    ));
+    
+    //add lootpack
+    
+    return kobold;
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnDeath" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnIncomingPlayer" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+    </entity>
+    <entity name="bloodCavesBoss">
+      <script name="OnSpawn" enabled="true">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+
+                    
+    var fighter = new Humanoid()
+    {
+        Name = "Demonic Necromancer",
+        Body = 221, IsFemale = false,
+            
+        MaxHealth = 10500, Health = 10500,
+        BaseDodge = 27,
+        HideDetection = 40,
+        BasePenetration = ShieldPenetration.Light,
+        Experience = 48500,
+        CanSwim = false,
+        Alignment = Alignment.Evil,
+        Immunity = CreatureImmunity.Magic,
+        Weakness = CreatureWeakness.BlueGlowing | CreatureWeakness.IceSpearSpell | CreatureWeakness.DeathSpell,
+            
+    };
+        
+   fighter.AddStatus(new NightVisionStatus(fighter));
+    
+    fighter.CombatantChangeInterval = TimeSpan.FromSeconds(10.0);
+    
+    fighter.Attacks = new CreatureAttackCollection
+    {
+        {
+            new CreatureAttack(21,      58, 72,      "The Necromancer gouges you with his fist.",
+                                                        new AttackProneComponent(15), 
+                                                        new AttackStunComponent(5)),                40
+        },
+        {
+            new CreatureAttack(22,      66, 79,     "The Necromancer smashes you with his scythe.",
+                                                        new AttackProneComponent(25), 
+                                                        new AttackStunComponent(10)),               40
+        },
+        {
+            new CreatureAttack(25,      77, 105,     "The Necromancer surrounds you in his evil robe.",
+                                                        new AttackProneComponent(35), 
+                                                        new AttackStunComponent(15)),               20
+        },
+    };
+    
+    fighter.Wield(new Longsword());
+    fighter.Equip(new PlatemailArmor());    
+    
+    fighter.AddGold(4450);
+  fighter.AddLoot(new LootPack(
+        new LootPackEntry(true, (from, container) => new PearDiamond(3000u),    100, gemsPriceMutator),
+        new LootPackEntry(true, (from, container) => new PearDiamond(3000u),    50, gemsPriceMutator),
+        new LootPackEntry(true, (from, container) => new PearDiamond(3000u),    50, gemsPriceMutator),
+        new LootPackEntry(true, (from, container) => new BearSkull(),        100),
+        new LootPackEntry(true, (from, container) => new YouthPotion(),        100),
+         new LootPackEntry(true, SemiRare, 40),
+        new LootPackEntry(true, (from, container) => new SilverDaggerAmulet(),        40),        
+        new LootPackEntry(true, UltraRare, 25)
+	));
+    return fighter;
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnDeath" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnIncomingPlayer" enabled="true">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+source.Say($"Oh, you've dealth with my pets have you? {player.Name} let us play shall we?");
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+    </entity>
+    <entity name="bloodCavesDemon">
+      <script name="OnSpawn" enabled="true">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+	 var demon = new Wraith()
+    {
+        MaxHealth = 450, Health = 450,
+        BaseDodge = 25,
+        Name = "Demon",
+        Body = 63,
+        Alignment = Alignment.Evil,
+    
+        Experience = 32725,
+        
+    };
+    demon.AddStatus(new NightVisionStatus(demon));
+        
+    demon.Attacks = new CreatureAttackCollection()
+    {
+        new CreatureBasicAttack(45)
+    };
+    
+    demon.Spells =  new CreatureSpellCollection()
+    {
+        new CreatureSpell<DeathSpell>(
+            skillLevel: 14,
+            mantra: SpellHelper.GenerateMantra(), instantCast: false)
+    };
+        
+    demon.Wield(new WoodenStaff());
+    demon.AddGold(700);
+    return demon;
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnDeath" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnIncomingPlayer" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+    </entity>
+    <entity name="forestBoss2a">
+      <script name="OnSpawn" enabled="true">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+	
+    var twin = new AncientLich()
+    {
+        Name = "Gortin",
+        Body = 209,
+        
+        MaxHealth = 4775, Health = 4775, /* Based on 4 Death casts to kill at level 16 magic. */
+        BaseDodge = 25,
+        
+        Experience = 35000,
+        
+        BasePenetration = ShieldPenetration.Heavy,
+        CanLoot = false,
+        CanJumpkick = true,
+        
+        FireProtection = 100,
+        IceProtection = 100,
+        LightningResistance = 100,
+    };
+    
+    twin.AddStatus(new NightVisionStatus(twin));
+    
+    twin.Attacks = new CreatureAttackCollection
+    {
+        new CreatureBasicAttack(22, 40, 60,
+                    new AttackAgeComponent(1000, 20), new AttackProneComponent(15))
+    };
+    
+    twin.Spells = new CreatureSpellCollection(100)
+    {
+       { new CreatureSpell<FireStormSpell>(
+            skillLevel: 12), 100, TimeSpan.FromSeconds(12.0) }
+    };
+
+    twin.AddGold(2000);
+    twin.AddLoot(
+        new LootPack(
+        new LootPackEntry(true, (from, container) => new PearDiamond(3000u),    100, gemsPriceMutator),
+        new LootPackEntry(true, (from, container) => new PearDiamond(3000u),    50, gemsPriceMutator),
+        new LootPackEntry(true, (from, container) => new PearDiamond(3000u),    50, gemsPriceMutator),
+        new LootPackEntry(true, (from, container) => new BearSkull(),        100),
+        new LootPackEntry(true, (from, container) => new YouthPotion(),        100),
+         new LootPackEntry(true, SemiRare, 40),
+        new LootPackEntry(true, (from, container) => new SilverDaggerAmulet(),        40),        
+        new LootPackEntry(true, UltraRare, 25)
+        ));
+    
+    return twin;
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnDeath" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnIncomingPlayer" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+    </entity>
+    <entity name="forestBoss2b">
+      <script name="OnSpawn" enabled="true">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+	
+    var twin = new AncientLich()
+    {
+        Name = "Norlaq",
+        Body = 209,
+        
+        MaxHealth = 600, Health = 600,
+        BaseDodge = 25,
+        
+        Experience = 55000,
+        
+        BasePenetration = ShieldPenetration.Heavy,
+        CanLoot = false,
+        CanJumpkick = true,
+        
+        FireProtection = 100,
+        IceProtection = 100,
+        LightningResistance = 100,
+    };
+    
+    twin.AddStatus(new NightVisionStatus(twin));
+    
+    twin.Attacks = new CreatureAttackCollection
+    {
+        new CreatureBasicAttack(22, 55, 70,
+                new AttackAgeComponent(1000, 20),
+                new AttackProneComponent(15))
+    };
+    
+    twin.Spells = new CreatureSpellCollection(100)
+    {
+        { new CreatureSpell<DragonBreathLightningSpell>(
+            skillLevel: 12), 100, TimeSpan.FromSeconds(12.0) }
+    };
+    
+    twin.AddGold(2000);
+    twin.AddLoot(
+        new LootPack(
+        new LootPackEntry(true, (from, container) => new PearDiamond(3000u),    100, gemsPriceMutator),
+        new LootPackEntry(true, (from, container) => new PearDiamond(3000u),    50, gemsPriceMutator),
+        new LootPackEntry(true, (from, container) => new PearDiamond(3000u),    50, gemsPriceMutator),
+        new LootPackEntry(true, (from, container) => new BearSkull(),        100),
+        new LootPackEntry(true, (from, container) => new YouthPotion(),        100),
+         new LootPackEntry(true, SemiRare, 40),
+        new LootPackEntry(true, (from, container) => new SilverDaggerAmulet(),        40),        
+        new LootPackEntry(true, UltraRare, 25)
+        ));
+
+    
+    return twin;
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnDeath" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnIncomingPlayer" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+    </entity>
+    <entity name="caveWolfy">
+      <script name="OnSpawn" enabled="true">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+	var wolf = new Wolf()
+    {
+        Name = "Feral Cave Wolf",
+        MaxHealth = 425, Health = 425,
+        BaseDodge = 29,
+        Body = 242,
+        BasePenetration = ShieldPenetration.Heavy,
+        Experience = 22000,
+
+        MagicProtection = 50,
+    };
+    
+    wolf.AddStatus(new NightVisionStatus(wolf));
+    
+    wolf.Attacks = new CreatureAttackCollection
+    {
+            { 
+                new CreatureAttack(19, 22, 35, "The wolf rakes you with its claws."),         50 
+            }, 
+            {
+                new CreatureAttack(20, 35, 43, "The wolf sinks its teeth into you."),         30
+            }, 
+            { 
+                new CreatureAttack(21, 43, 55, "The wolf lunges at you, biting into your neck."), 20 
+            }, 
+    };
+    
+    wolf.Blocks = new CreatureBlockCollection
+    {
+            new CreatureBlock(7, "your weapon passing through a tuft of fur"),
+            new CreatureBlock(6, "a hardened paw"),
+    };
+
+   wolf.AddGold(1000);
+      wolf.AddLoot(new LootPack(
+        new LootPackEntry(true, drop3gems,       10,     gemsPriceMutator), 
+        new LootPackEntry(true, GenericBottles,    33),
+        new LootPackEntry(true, SemiRare, 3)
+    ));
+
+    return wolf;
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnDeath" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnIncomingPlayer" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+    </entity>
+    <entity name="caveBoar">
+      <script name="OnSpawn" enabled="true">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+	var boar = new Boar()
+    {
+        Name = "Feral Cave boar",
+        MaxHealth = 325, Health = 325,
+        BaseDodge = 29,
+        BasePenetration = ShieldPenetration.Heavy,
+        Experience = 19000,
+        CanCharge = true,
+        MagicProtection = 50,
+    };
+    
+    boar.AddStatus(new NightVisionStatus(boar));
+    
+    boar.Attacks = new CreatureAttackCollection
+    {
+            { 
+                new CreatureAttack(19, 22, 35, "The boar rakes you with its tusks."),         50 
+            }, 
+            {
+                new CreatureAttack(20, 35, 43, "The boar sinks its teeth into you."),         30
+            }, 
+            { 
+                new CreatureAttack(21, 43, 55, "The boar lunges at you, biting into your neck."), 20 
+            }, 
+    };
+    
+    boar.Blocks = new CreatureBlockCollection
+    {
+            new CreatureBlock(7, "your weapon passing through a tuft of fur"),
+            new CreatureBlock(6, "a hardened tusk"),
+    };
+
+   boar.AddGold(1000);
+      boar.AddLoot(new LootPack(
+        new LootPackEntry(true, drop3gems,       10,     gemsPriceMutator), 
+        new LootPackEntry(true, GenericBottles,    33),
+        new LootPackEntry(true, SemiRare, 3)
+    ));
+
+    return boar;
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnDeath" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnIncomingPlayer" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+    </entity>
+    <entity name="caveBoss">
+      <script name="OnSpawn" enabled="true">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+    var critter = new Drake()
+    {
+        Name = "Feral Animal",
+        MaxHealth = 10900, Health = 10900,
+        BaseDodge = 31,
+        Body = 233,
+        MaxMana = 45,
+    
+        Alignment = Alignment.Evil,
+        HideDetection = 30,
+        Experience = 79000,
+        CanLoot = false,
+        
+        
+        CanCharge = true,
+        
+        BasePenetration = ShieldPenetration.Heavy,
+
+        Immunity = CreatureImmunity.Piercing | CreatureImmunity.Slashing | CreatureImmunity.Bashing |
+                   CreatureImmunity.Projectile | CreatureImmunity.Magic,
+        Weakness = CreatureWeakness.BlueGlowing | CreatureWeakness.DeathSpell | CreatureWeakness.IceSpearSpell,
+    
+    };
+    
+    critter.AddStatus(new NightVisionStatus(critter));
+    
+    critter.CombatantChangeInterval = TimeSpan.FromSeconds(10.0);
+    
+    critter.Attacks = new CreatureAttackCollection()
+    {
+        {
+            new CreatureAttack(19,      55, 70,      "The creature mauls you with its paw",
+                                                        new AttackProneComponent(15), 
+                                                        new AttackStunComponent(5)),                40
+        },
+        {
+            new CreatureAttack(21,      60, 75,     "The creature smashes you with its hind legs.",
+                                                        new AttackProneComponent(25), 
+                                                        new AttackStunComponent(10)),               40
+        },
+        {
+            new CreatureAttack(25,      70, 89,     "The creature pierces you with its horn.",
+                                                        new AttackProneComponent(35), 
+                                                        new AttackStunComponent(15)),               20
+        },
+    };
+    
+    critter.Blocks = new CreatureBlockCollection
+    {
+        new CreatureBlock(10, "an appendage"),
+        new CreatureBlock(8, "a foot"),
+        new CreatureBlock(7, "something disgusting, now coating your weapon"),
+    };
+        
+    critter.Spells = new CreatureSpellCollection(20.0)
+    {
+        new CreatureSpell<WhirlwindSpell>(
+            skillLevel: 11, cost: 25),
+    };
+    
+    critter.AddGold(5000);
+     critter.AddGold(1000);
+      critter.AddLoot(new LootPack(
+        new LootPackEntry(true, drop3gems,       10,     gemsPriceMutator), 
+        new LootPackEntry(true, GenericBottles,    33),
+        new LootPackEntry(true, SemiRare, 3),
+         new LootPackEntry(true, SemiRare, 40),
+        new LootPackEntry(true, (from, container) => new SilverDaggerAmulet(),        40),
+        new LootPackEntry(true, (from, container) => new BrightFeather(), 40),
+        new LootPackEntry(true, UltraRare, 25)
+    ));
+    
+    return critter;
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnDeath" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnIncomingPlayer" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+    </entity>
+    <entity name="bloodCavesAbominationRanged">
+      <script name="OnSpawn" enabled="true">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+	var female = Utility.RandomBool();
+                    
+    var abomination = new Humanoid()
+    {
+        Name = "Abomination",
+        Body = 246, IsFemale = female,
+            
+        MaxHealth = 255, Health = 455,
+        BaseDodge = 26,
+        BasePenetration = ShieldPenetration.Light,
+        Experience = 27000,
+        CanSwim = true,
+            
+    };
+        
+    abomination.Attacks = new CreatureAttackCollection
+    {
+        new CreatureBasicAttack(20, 35, 55)
+    };
+    
+    abomination.Wield(new FineCrossbow());
+    abomination.Equip(new PlatemailArmor());    
+    
+    abomination.AddGold(1450);
+    abomination.AddLoot(new LootPack(
+        new LootPackEntry(true, drop3gems,       10,     gemsPriceMutator), 
+        new LootPackEntry(true, GenericBottles,    33),
+        new LootPackEntry(true, SemiRare, 3)
+    ));
+    //todo add lootpack
+    
+    return abomination;
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
@@ -90649,26 +92267,6 @@ if (spawn is Shopkeeper shopkeeper)
       <entry entity="townBalmVendor" size="1" minimum="1" maximum="1" />
       <location x="2" y="2" region="5" />
     </spawn>
-    <spawn type="LocationSpawner" name="towerTopGiant">
-      <minimumDelay>0</minimumDelay>
-      <maximumDelay>0</maximumDelay>
-      <script name="OnAfterSpawn" enabled="false">
-        <block><![CDATA[]]></block>
-        <block><![CDATA[
-
-]]></block>
-        <block><![CDATA[]]></block>
-      </script>
-      <script name="OnBeforeSpawn" enabled="false">
-        <block><![CDATA[]]></block>
-        <block><![CDATA[
-
-]]></block>
-        <block><![CDATA[]]></block>
-      </script>
-      <entry entity="towerTopGiant" size="1" minimum="1" maximum="1" />
-      <location x="0" y="0" region="0" />
-    </spawn>
     <spawn type="LocationSpawner" name="300EvilStatue1">
       <minimumDelay>4500</minimumDelay>
       <maximumDelay>4500</maximumDelay>
@@ -90687,7 +92285,7 @@ if (spawn is Shopkeeper shopkeeper)
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="300EvilStatue" size="1" minimum="1" maximum="1" />
+      <entry entity="evilStatue300" size="1" minimum="1" maximum="1" />
       <location x="11" y="32" region="5" />
     </spawn>
     <spawn type="LocationSpawner" name="300EvilStatue2">
@@ -90708,7 +92306,7 @@ if (spawn is Shopkeeper shopkeeper)
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="300EvilStatue" size="1" minimum="1" maximum="1" />
+      <entry entity="evilStatue300" size="1" minimum="1" maximum="1" />
       <location x="8" y="36" region="5" />
     </spawn>
     <spawn type="LocationSpawner" name="300EvilStatueDock">
@@ -90729,30 +92327,8 @@ if (spawn is Shopkeeper shopkeeper)
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="300EvilStatue" size="1" minimum="1" maximum="1" />
+      <entry entity="evilStatue300" size="1" minimum="1" maximum="1" />
       <location x="3" y="18" region="5" />
-    </spawn>
-    <spawn type="LocationSpawner" name="300King">
-      <minimumDelay>3600</minimumDelay>
-      <maximumDelay>10800</maximumDelay>
-      <maximum>1</maximum>
-      <script name="OnAfterSpawn" enabled="false">
-        <block><![CDATA[]]></block>
-        <block><![CDATA[
-
-]]></block>
-        <block><![CDATA[]]></block>
-      </script>
-      <script name="OnBeforeSpawn" enabled="false">
-        <block><![CDATA[]]></block>
-        <block><![CDATA[
-
-]]></block>
-        <block><![CDATA[]]></block>
-      </script>
-      <entry entity="300King" size="1" minimum="1" maximum="1" />
-      <entry entity="300Queen" size="1" minimum="1" maximum="1" />
-      <location x="12" y="35" region="5" />
     </spawn>
     <spawn type="LocationSpawner" name="forestunicorn">
       <minimumDelay>8100</minimumDelay>
@@ -90776,8 +92352,8 @@ if (spawn is Shopkeeper shopkeeper)
       <location x="8" y="-13" region="9" />
     </spawn>
     <spawn type="RegionSpawner" name="surfaceFishNorth">
-      <minimumDelay>900</minimumDelay>
-      <maximumDelay>1200</maximumDelay>
+      <minimumDelay>660</minimumDelay>
+      <maximumDelay>900</maximumDelay>
       <maximum>25</maximum>
       <script name="OnAfterSpawn" enabled="false">
         <block><![CDATA[]]></block>
@@ -90798,6 +92374,7 @@ if (spawn is Shopkeeper shopkeeper)
       <entry entity="surfaceShark" size="1" minimum="1" maximum="2" />
       <entry entity="surfaceBloodGrif" size="1" minimum="1" maximum="2" />
       <entry entity="surfaceGreaterLurker" size="1" minimum="1" maximum="1" />
+      <entry entity="surfaceWyvern300" size="3" minimum="1" maximum="2" />
       <bounds region="1">
         <inclusion left="0" top="-14" right="23" bottom="-3" />
         <exclusion left="0" top="0" right="0" bottom="0" />
@@ -90829,7 +92406,7 @@ if (spawn is Shopkeeper shopkeeper)
     </spawn>
     <spawn type="RegionSpawner" name="surfaceHut">
       <minimumDelay>900</minimumDelay>
-      <maximumDelay>1200</maximumDelay>
+      <maximumDelay>2700</maximumDelay>
       <maximum>2</maximum>
       <script name="OnAfterSpawn" enabled="false">
         <block><![CDATA[]]></block>
@@ -90855,7 +92432,7 @@ if (spawn is Shopkeeper shopkeeper)
     <spawn type="RegionSpawner" name="300Keep">
       <minimumDelay>720</minimumDelay>
       <maximumDelay>900</maximumDelay>
-      <maximum>1</maximum>
+      <maximum>13</maximum>
       <script name="OnAfterSpawn" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -90870,8 +92447,8 @@ if (spawn is Shopkeeper shopkeeper)
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="300Dweller" size="2" minimum="5" maximum="9" />
-      <entry entity="300CastleSpectre" size="1" minimum="2" maximum="4" />
+      <entry entity="dweller300" size="2" minimum="5" maximum="9" />
+      <entry entity="castlespec300" size="1" minimum="2" maximum="4" />
       <bounds region="5">
         <inclusion left="0" top="25" right="16" bottom="29" />
         <exclusion left="0" top="0" right="0" bottom="0" />
@@ -90925,10 +92502,10 @@ if (spawn is Shopkeeper shopkeeper)
         <exclusion left="0" top="0" right="0" bottom="0" />
       </bounds>
     </spawn>
-    <spawn type="RegionSpawner" name="100North">
+    <spawn type="RegionSpawner" name="100north">
       <minimumDelay>600</minimumDelay>
       <maximumDelay>900</maximumDelay>
-      <maximum>17</maximum>
+      <maximum>18</maximum>
       <script name="OnAfterSpawn" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -90943,18 +92520,18 @@ if (spawn is Shopkeeper shopkeeper)
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="100Hobs" size="1" minimum="1" maximum="2" />
-      <entry entity="100Archer" size="2" minimum="5" maximum="5" />
-      <entry entity="100Kobald" size="3" minimum="4" maximum="9" />
+      <entry entity="hobs100" size="1" minimum="1" maximum="2" />
+      <entry entity="archer100" size="2" minimum="5" maximum="5" />
+      <entry entity="kobald100" size="3" minimum="4" maximum="9" />
       <bounds region="3">
         <inclusion left="0" top="0" right="17" bottom="8" />
         <exclusion left="0" top="0" right="0" bottom="0" />
       </bounds>
     </spawn>
-    <spawn type="RegionSpawner" name="100South">
+    <spawn type="RegionSpawner" name="100south">
       <minimumDelay>600</minimumDelay>
       <maximumDelay>900</maximumDelay>
-      <maximum>17</maximum>
+      <maximum>18</maximum>
       <script name="OnAfterSpawn" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -90969,9 +92546,9 @@ if (spawn is Shopkeeper shopkeeper)
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="100Hobs" size="1" minimum="1" maximum="2" />
-      <entry entity="100Archer" size="2" minimum="5" maximum="5" />
-      <entry entity="100Archer" size="3" minimum="4" maximum="9" />
+      <entry entity="hobs100" size="1" minimum="1" maximum="2" />
+      <entry entity="archer100" size="2" minimum="5" maximum="5" />
+      <entry entity="archer100" size="3" minimum="4" maximum="9" />
       <bounds region="3">
         <inclusion left="0" top="8" right="23" bottom="18" />
         <exclusion left="0" top="0" right="0" bottom="0" />
@@ -91058,7 +92635,7 @@ if (spawn is Shopkeeper shopkeeper)
     </spawn>
     <spawn type="RegionSpawner" name="SurfaceNook">
       <minimumDelay>600</minimumDelay>
-      <maximumDelay>720</maximumDelay>
+      <maximumDelay>900</maximumDelay>
       <maximum>5</maximum>
       <script name="OnAfterSpawn" enabled="false">
         <block><![CDATA[]]></block>
@@ -91074,7 +92651,7 @@ if (spawn is Shopkeeper shopkeeper)
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="surfaceOrc" size="2" minimum="4" maximum="7" />
+      <entry entity="surfaceOrc" size="2" minimum="3" maximum="5" />
       <bounds region="1">
         <inclusion left="0" top="-14" right="1" bottom="-12" />
         <exclusion left="0" top="0" right="0" bottom="0" />
@@ -91098,16 +92675,17 @@ if (spawn is Shopkeeper shopkeeper)
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="surfaceBanshee" size="2" minimum="4" maximum="4" />
-      <bounds region="3">
+      <entry entity="surfaceBanshee" size="2" minimum="2" maximum="3" />
+      <entry entity="newGhoul" size="1" minimum="1" maximum="1" />
+      <bounds region="2">
         <inclusion left="0" top="0" right="5" bottom="6" />
         <exclusion left="0" top="0" right="0" bottom="0" />
       </bounds>
     </spawn>
-    <spawn type="RegionSpawner" name="KeepOfDarknessBoss">
+    <spawn type="RegionSpawner" name="keepOfDarknessBoss">
       <minimumDelay>5700</minimumDelay>
       <maximumDelay>10800</maximumDelay>
-      <maximum>4</maximum>
+      <maximum>5</maximum>
       <script name="OnAfterSpawn" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -91122,11 +92700,11 @@ if (spawn is Shopkeeper shopkeeper)
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="KeepOfDarknessBoss" size="1" minimum="1" maximum="1" />
+      <entry entity="keepOfDarknessBoss" size="1" minimum="1" maximum="1" />
       <entry entity="SouthernDarknessLich" size="1" minimum="2" maximum="2" />
       <entry entity="towerSkeleton" size="1" minimum="2" maximum="2" />
       <bounds region="1">
-        <inclusion left="6" top="54" right="9" bottom="59" />
+        <inclusion left="6" top="54" right="10" bottom="60" />
         <exclusion left="0" top="0" right="0" bottom="0" />
       </bounds>
     </spawn>
@@ -91149,9 +92727,9 @@ if (spawn is Shopkeeper shopkeeper)
         <block><![CDATA[]]></block>
       </script>
       <entry entity="surfaceOrc" size="2" minimum="5" maximum="8" />
-      <entry entity="100Kobald" size="3" minimum="4" maximum="9" />
-      <entry entity="100Hobs" size="1" minimum="2" maximum="2" />
-      <entry entity="100Archer" size="2" minimum="1" maximum="2" />
+      <entry entity="kobold200" size="3" minimum="4" maximum="9" />
+      <entry entity="hobs200" size="1" minimum="2" maximum="2" />
+      <entry entity="archer200" size="2" minimum="1" maximum="3" />
       <bounds region="4">
         <inclusion left="2" top="0" right="23" bottom="6" />
         <exclusion left="0" top="0" right="0" bottom="0" />
@@ -91176,18 +92754,18 @@ if (spawn is Shopkeeper shopkeeper)
         <block><![CDATA[]]></block>
       </script>
       <entry entity="surfaceOrc" size="2" minimum="5" maximum="8" />
-      <entry entity="100Kobald" size="3" minimum="4" maximum="9" />
-      <entry entity="100Hobs" size="1" minimum="2" maximum="2" />
-      <entry entity="100Archer" size="2" minimum="1" maximum="2" />
+      <entry entity="kobold200" size="3" minimum="4" maximum="9" />
+      <entry entity="hobs200" size="1" minimum="2" maximum="2" />
+      <entry entity="archer200" size="2" minimum="1" maximum="2" />
       <bounds region="4">
         <inclusion left="0" top="11" right="23" bottom="18" />
         <exclusion left="0" top="0" right="0" bottom="0" />
       </bounds>
     </spawn>
     <spawn type="RegionSpawner" name="200boss">
-      <minimumDelay>120</minimumDelay>
+      <minimumDelay>7320</minimumDelay>
       <maximumDelay>10800</maximumDelay>
-      <maximum>5</maximum>
+      <maximum>9</maximum>
       <script name="OnAfterSpawn" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -91202,9 +92780,10 @@ if (spawn is Shopkeeper shopkeeper)
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="200boss" size="1" minimum="1" maximum="1" />
+      <entry entity="boss200" size="1" minimum="1" maximum="1" />
       <entry entity="surfaceOrc" size="2" minimum="2" maximum="2" />
-      <entry entity="100Kobald" size="1" minimum="2" maximum="2" />
+      <entry entity="kobold200" size="2" minimum="2" maximum="2" />
+      <entry entity="pirhana300" size="3" minimum="3" maximum="4" />
       <bounds region="4">
         <inclusion left="9" top="6" right="15" bottom="12" />
         <exclusion left="0" top="0" right="0" bottom="0" />
@@ -91233,14 +92812,15 @@ if (spawn is Shopkeeper shopkeeper)
       <entry entity="surfaceShark" size="1" minimum="1" maximum="2" />
       <entry entity="surfaceBloodGrif" size="1" minimum="1" maximum="2" />
       <entry entity="surfaceGreaterLurker" size="1" minimum="1" maximum="1" />
+      <entry entity="surfaceWyvern300" size="3" minimum="1" maximum="2" />
       <bounds region="1">
         <inclusion left="0" top="0" right="21" bottom="21" />
         <exclusion left="13" top="0" right="19" bottom="2" />
       </bounds>
     </spawn>
     <spawn type="RegionSpawner" name="surfaceChildren">
-      <minimumDelay>420</minimumDelay>
-      <maximumDelay>600</maximumDelay>
+      <minimumDelay>660</minimumDelay>
+      <maximumDelay>1500</maximumDelay>
       <maximum>6</maximum>
       <script name="OnAfterSpawn" enabled="false">
         <block><![CDATA[]]></block>
@@ -91339,8 +92919,8 @@ if (spawn is Shopkeeper shopkeeper)
       </bounds>
     </spawn>
     <spawn type="RegionSpawner" name="300surface">
-      <minimumDelay>0</minimumDelay>
-      <maximumDelay>0</maximumDelay>
+      <minimumDelay>600</minimumDelay>
+      <maximumDelay>900</maximumDelay>
       <maximum>35</maximum>
       <script name="OnAfterSpawn" enabled="false">
         <block><![CDATA[]]></block>
@@ -91356,13 +92936,13 @@ if (spawn is Shopkeeper shopkeeper)
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="surfacePirhana" size="2" minimum="4" maximum="9" />
-      <entry entity="300Lurker" size="1" minimum="2" maximum="4" />
-      <entry entity="300SurfaceWyvern" size="3" minimum="7" maximum="12" />
-      <entry entity="300Boss" size="1" minimum="1" maximum="1" />
-      <entry entity="300TrollGuards" size="2" minimum="4" maximum="6" />
-      <entry entity="300TrollGuardRanged" size="1" minimum="4" maximum="4" />
-      <entry entity="surfaceShark" size="1" minimum="2" maximum="2" />
+      <entry entity="pirhana300" size="2" minimum="4" maximum="9" />
+      <entry entity="lurker300" size="1" minimum="2" maximum="6" />
+      <entry entity="surfaceWyvern300" size="3" minimum="7" maximum="12" />
+      <entry entity="boss300water" size="1" minimum="1" maximum="1" />
+      <entry entity="trollGuards300" size="2" minimum="4" maximum="6" />
+      <entry entity="trollGuardRanged300" size="1" minimum="4" maximum="4" />
+      <entry entity="shark300" size="1" minimum="2" maximum="2" />
       <bounds region="5">
         <inclusion left="0" top="4" right="23" bottom="20" />
         <exclusion left="19" top="8" right="21" bottom="12" />
@@ -91370,9 +92950,9 @@ if (spawn is Shopkeeper shopkeeper)
       </bounds>
     </spawn>
     <spawn type="RegionSpawner" name="unicorn lair">
-      <minimumDelay>0</minimumDelay>
-      <maximumDelay>0</maximumDelay>
-      <maximum>4</maximum>
+      <minimumDelay>2700</minimumDelay>
+      <maximumDelay>3660</maximumDelay>
+      <maximum>2</maximum>
       <script name="OnAfterSpawn" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -91396,6 +92976,7 @@ if (spawn is Shopkeeper shopkeeper)
     <spawn type="RegionSpawner" name="300Hut">
       <minimumDelay>0</minimumDelay>
       <maximumDelay>0</maximumDelay>
+      <maximum>1</maximum>
       <script name="OnAfterSpawn" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -91410,8 +92991,8 @@ if (spawn is Shopkeeper shopkeeper)
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="300HutKeeper" size="1" minimum="1" maximum="1" />
-      <bounds region="0">
+      <entry entity="hutKeeper300" size="1" minimum="1" maximum="1" />
+      <bounds region="5">
         <inclusion left="19" top="8" right="20" bottom="11" />
         <exclusion left="0" top="0" right="0" bottom="0" />
       </bounds>
@@ -91467,6 +93048,7 @@ if (spawn is Shopkeeper shopkeeper)
       <entry entity="forestCentaur" size="1" minimum="2" maximum="2" />
       <entry entity="surfacePirhana" size="2" minimum="2" maximum="3" />
       <entry entity="surfaceLurker" size="1" minimum="1" maximum="1" />
+      <entry entity="archer200" size="2" minimum="2" maximum="4" />
       <bounds region="9">
         <inclusion left="-30" top="5" right="-5" bottom="20" />
         <exclusion left="0" top="0" right="0" bottom="0" />
@@ -91498,6 +93080,7 @@ if (spawn is Shopkeeper shopkeeper)
       <entry entity="forestSnake" size="1" minimum="1" maximum="2" />
       <entry entity="surfacePirhana" size="2" minimum="2" maximum="4" />
       <entry entity="surfaceLurker" size="1" minimum="1" maximum="1" />
+      <entry entity="archer200" size="2" minimum="2" maximum="4" />
       <bounds region="9">
         <inclusion left="-39" top="-21" right="-4" bottom="-2" />
         <exclusion left="-26" top="-7" right="-24" bottom="-6" />
@@ -91533,7 +93116,7 @@ if (spawn is Shopkeeper shopkeeper)
     <spawn type="RegionSpawner" name="forestUpper">
       <minimumDelay>900</minimumDelay>
       <maximumDelay>1080</maximumDelay>
-      <maximum>20</maximum>
+      <maximum>25</maximum>
       <script name="OnAfterSpawn" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -91548,13 +93131,15 @@ if (spawn is Shopkeeper shopkeeper)
 ]]></block>
         <block><![CDATA[]]></block>
       </script>
-      <entry entity="surfaceLurker" size="1" minimum="1" maximum="1" />
-      <entry entity="surfacePirhana" size="2" minimum="2" maximum="2" />
+      <entry entity="lurker300" size="1" minimum="1" maximum="1" />
+      <entry entity="pirhana300" size="2" minimum="2" maximum="2" />
       <entry entity="forestBoar" size="2" minimum="3" maximum="5" />
       <entry entity="forestWolf" size="3" minimum="4" maximum="6" />
       <entry entity="forestBear" size="1" minimum="2" maximum="3" />
       <entry entity="forestGriffin" size="1" minimum="3" maximum="5" />
       <entry entity="forestCentaur" size="1" minimum="1" maximum="1" />
+      <entry entity="shark300" size="1" minimum="2" maximum="2" />
+      <entry entity="archer200" size="2" minimum="2" maximum="4" />
       <bounds region="9">
         <inclusion left="-30" top="-46" right="-9" bottom="-16" />
         <exclusion left="0" top="0" right="0" bottom="0" />
@@ -91584,6 +93169,7 @@ if (spawn is Shopkeeper shopkeeper)
       <entry entity="forestWolf" size="3" minimum="3" maximum="5" />
       <entry entity="forestSnake" size="1" minimum="1" maximum="1" />
       <entry entity="forestCentaur" size="1" minimum="1" maximum="1" />
+      <entry entity="archer200" size="2" minimum="2" maximum="4" />
       <bounds region="9">
         <inclusion left="-23" top="-73" right="9" bottom="-57" />
         <exclusion left="0" top="0" right="0" bottom="0" />
@@ -91592,7 +93178,7 @@ if (spawn is Shopkeeper shopkeeper)
     <spawn type="RegionSpawner" name="bloodCaves">
       <minimumDelay>480</minimumDelay>
       <maximumDelay>720</maximumDelay>
-      <maximum>15</maximum>
+      <maximum>25</maximum>
       <script name="OnAfterSpawn" enabled="false">
         <block><![CDATA[]]></block>
         <block><![CDATA[
@@ -91608,10 +93194,201 @@ if (spawn is Shopkeeper shopkeeper)
         <block><![CDATA[]]></block>
       </script>
       <entry entity="bloodCavesAbomination" size="2" minimum="5" maximum="7" />
-      <entry entity="bloodCaveBanshee" size="2" minimum="4" maximum="5" />
-      <entry entity="bloodCaveBat" size="2" minimum="3" maximum="3" />
+      <entry entity="bloodCaveBanshee" size="2" minimum="3" maximum="3" />
+      <entry entity="bloodCaveBat" size="2" minimum="3" maximum="4" />
+      <entry entity="newGhoul" size="1" minimum="3" maximum="5" />
+      <entry entity="shark300" size="1" minimum="1" maximum="2" />
+      <entry entity="pirhana300" size="3" minimum="2" maximum="2" />
+      <entry entity="surfaceGreaterLurker" size="1" minimum="1" maximum="1" />
+      <entry entity="castlespec300" size="1" minimum="1" maximum="1" />
+      <entry entity="SouthernDarknessLich" size="1" minimum="2" maximum="2" />
+      <entry entity="bloodCavesAbominationRanged" size="1" minimum="2" maximum="2" />
+      <entry entity="caveWolfy" size="1" minimum="1" maximum="1" />
       <bounds region="11">
         <inclusion left="2" top="1" right="31" bottom="21" />
+        <exclusion left="0" top="0" right="0" bottom="0" />
+      </bounds>
+    </spawn>
+    <spawn type="RegionSpawner" name="towerTopGiant">
+      <minimumDelay>3600</minimumDelay>
+      <maximumDelay>7320</maximumDelay>
+      <maximum>1</maximum>
+      <script name="OnAfterSpawn" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnBeforeSpawn" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <entry entity="towerTopGiant" size="1" minimum="1" maximum="1" />
+      <bounds region="8">
+        <inclusion left="-2" top="-1" right="0" bottom="3" />
+        <exclusion left="0" top="0" right="0" bottom="0" />
+      </bounds>
+    </spawn>
+    <spawn type="RegionSpawner" name="bloodCavesBoss">
+      <minimumDelay>7200</minimumDelay>
+      <maximumDelay>14400</maximumDelay>
+      <maximum>3</maximum>
+      <script name="OnAfterSpawn" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnBeforeSpawn" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <entry entity="bloodCavesBoss" size="1" minimum="1" maximum="1" />
+      <entry entity="bloodCavesDemon" size="1" minimum="1" maximum="2" />
+      <bounds region="11">
+        <inclusion left="33" top="12" right="42" bottom="16" />
+        <exclusion left="0" top="0" right="0" bottom="0" />
+      </bounds>
+    </spawn>
+    <spawn type="RegionSpawner" name="forestBoss2">
+      <minimumDelay>7200</minimumDelay>
+      <maximumDelay>10800</maximumDelay>
+      <maximum>2</maximum>
+      <script name="OnAfterSpawn" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnBeforeSpawn" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <entry entity="forestBoss2a" size="1" minimum="1" maximum="1" />
+      <entry entity="forestBoss2b" size="1" minimum="2" maximum="2" />
+      <bounds region="9">
+        <inclusion left="-28" top="-52" right="-23" bottom="-50" />
+        <exclusion left="0" top="0" right="0" bottom="0" />
+      </bounds>
+    </spawn>
+    <spawn type="RegionSpawner" name="forrestCaves">
+      <minimumDelay>660</minimumDelay>
+      <maximumDelay>900</maximumDelay>
+      <maximum>24</maximum>
+      <script name="OnAfterSpawn" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnBeforeSpawn" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <entry entity="caveWolfy" size="2" minimum="5" maximum="9" />
+      <entry entity="forestBear" size="1" minimum="2" maximum="3" />
+      <entry entity="caveBoar" size="1" minimum="3" maximum="5" />
+      <entry entity="pirhana300" size="3" minimum="2" maximum="3" />
+      <entry entity="newGhoul" size="1" minimum="1" maximum="1" />
+      <entry entity="bloodCaveBat" size="1" minimum="2" maximum="2" />
+      <entry entity="shark300" size="1" minimum="1" maximum="1" />
+      <entry entity="lurker300" size="1" minimum="1" maximum="1" />
+      <entry entity="archer200" size="1" minimum="1" maximum="1" />
+      <bounds region="10">
+        <inclusion left="5" top="-2" right="31" bottom="9" />
+        <exclusion left="0" top="0" right="0" bottom="0" />
+      </bounds>
+    </spawn>
+    <spawn type="RegionSpawner" name="300Keep2">
+      <minimumDelay>660</minimumDelay>
+      <maximumDelay>900</maximumDelay>
+      <maximum>5</maximum>
+      <script name="OnAfterSpawn" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnBeforeSpawn" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <entry entity="dweller300" size="1" minimum="3" maximum="4" />
+      <entry entity="trollGuards300" size="1" minimum="1" maximum="2" />
+      <bounds region="5">
+        <inclusion left="0" top="22" right="4" bottom="38" />
+        <exclusion left="0" top="0" right="0" bottom="0" />
+      </bounds>
+    </spawn>
+    <spawn type="RegionSpawner" name="throneRoom300">
+      <minimumDelay>7200</minimumDelay>
+      <maximumDelay>10800</maximumDelay>
+      <maximum>2</maximum>
+      <script name="OnAfterSpawn" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnBeforeSpawn" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <entry entity="king300" size="1" minimum="1" maximum="1" />
+      <entry entity="queen300" size="1" minimum="1" maximum="1" />
+      <bounds region="5">
+        <inclusion left="9" top="34" right="15" bottom="37" />
+        <exclusion left="0" top="0" right="0" bottom="0" />
+      </bounds>
+    </spawn>
+    <spawn type="RegionSpawner" name="bloodCavesWaitingArea">
+      <minimumDelay>1800</minimumDelay>
+      <maximumDelay>3600</maximumDelay>
+      <maximum>5</maximum>
+      <script name="OnAfterSpawn" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <script name="OnBeforeSpawn" enabled="false">
+        <block><![CDATA[]]></block>
+        <block><![CDATA[
+
+]]></block>
+        <block><![CDATA[]]></block>
+      </script>
+      <entry entity="newGhoul" size="1" minimum="2" maximum="3" />
+      <entry entity="bloodCaveBanshee" size="2" minimum="1" maximum="1" />
+      <entry entity="bloodCavesAbomination" size="1" minimum="1" maximum="1" />
+      <entry entity="bloodCavesAbominationRanged" size="1" minimum="1" maximum="1" />
+      <bounds region="11">
+        <inclusion left="33" top="20" right="37" bottom="22" />
         <exclusion left="0" top="0" right="0" bottom="0" />
       </bounds>
     </spawn>


### PR DESCRIPTION
* fix to the Pit spawns and -100...

* fixed spawns in 100, 200, 300

* tons of fixes and enhancements

fixed trees not allowing hide, added some new mobs, did some balancing on mobs

* more fixes - bosses can't loot, etc

* fixed southern darkness keep boss spawn

* slight update on mob loot

* fixed syntax issues

* Update Bloodlands.mapproj

* couple of crazy attack fixes and lack of exp

* Update Bloodlands.mapproj

* added breath water to abominations

* v0.76

* Update Underkingdom.mapproj (#795)

Lurkers immune to Poison
Green Wyverns immune to poison
Orugugra Immune to Poison
Added immunity to magic to Mummy (Councilor), but made him weak to Death and Icespeare
Added Weakness to Death to SwordMaster
added piercing immunity to skeletons but made them weak to silver
Made Shelob poison weaker, she is currently harder than Carfel.

* Add immunities

Co-authored-by: Jalpesh Kachhadia <jalpeshk@gmail.com>
Co-authored-by: Wirednuke83 <89415412+Wirednuke83@users.noreply.github.com>